### PR TITLE
Remove: duplicate `Who's using Landscapist?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,13 +512,6 @@ FrescoWebImage(
 )
 ```
 
-## Who's using Landscapist?
-If your project uses Landscapist, let me know via creating a new issue! 🤗
-
-## [Twitter for Android](https://user-images.githubusercontent.com/24237865/125583736-f0ffa76f-8f87-433b-a9fd-192231dc5e63.jpg)
-
-[![twitter](https://user-images.githubusercontent.com/24237865/125583182-9527dd48-433e-4e17-ae52-3f2bb544a847.jpg)](https://play.google.com/store/apps/details?id=com.twitter.android&hl=ko&gl=US)
-
 ## Reference repository
 This library is mostly inspired by [Accompanist](https://github.com/chrisbanes/accompanist). <br>
 


### PR DESCRIPTION
Removed the duplicate part of `Who's using Landscapist?` in the README.