### PR TITLE
Replace nullable imageUrl to empty string for FrescoImage

### DIFF
--- a/fresco/src/main/java/com/skydoves/landscapist/fresco/LocalFrescoProvider.kt
+++ b/fresco/src/main/java/com/skydoves/landscapist/fresco/LocalFrescoProvider.kt
@@ -37,6 +37,6 @@ internal object LocalFrescoProvider {
   @Composable
   fun getFrescoImageRequest(imageUrl: String?): ImageRequest {
     return LocalFrescoImageRequest.current
-      ?: ImageRequestBuilder.newBuilderWithSource(Uri.parse(imageUrl)).build()
+      ?: ImageRequestBuilder.newBuilderWithSource(Uri.parse(imageUrl ?: "")).build()
   }
 }


### PR DESCRIPTION
## Guidelines
Replace nullable imageUrl to empty string for FrescoImage. (#62)