### PR TITLE
Change the naming convention about CircularRevelaed to CircularReveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ GlideImage( // CoilImage, FrescoImage
  <img src="https://user-images.githubusercontent.com/24237865/95661452-6abad480-0b6a-11eb-91c4-7cbe40b77927.gif" align="right" width="26%"/>
 
 ## Circular Reveal Animation
-You can implement the circular reveal animation while drawing images with `circularRevealedEnabled` attribute as `true`.
+You can implement the circular reveal animation while drawing images with `circularRevealEnabled` attribute as `true`.
 
 ```kotlin
 GlideImage( // CoilImage, FrescoImage
@@ -476,14 +476,14 @@ GlideImage( // CoilImage, FrescoImage
   // Crop, Fit, Inside, FillHeight, FillWidth, None
   contentScale = ContentScale.Crop,
   // shows an image with a circular revealed animation.
-  circularRevealedEnabled = true,
+  circularRevealEnabled = true,
   // shows a placeholder ImageBitmap when loading.
   placeHolder = ImageBitmap.imageResource(R.drawable.placeholder),
   // shows an error ImageBitmap when the request failed.
   error = ImageBitmap.imageResource(R.drawable.error)
 )
 ```
-The default value of the `circularRevealedEnabled` is `false`.
+The default value of the `circularRevealEnabled` is `false`.
 
  > Note: You can also use the Circular Revewal Animation for **CoilImage** and **FrescoImage**.
 

--- a/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
+++ b/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
@@ -49,7 +49,7 @@ import coil.ImageLoader
 import coil.request.Disposable
 import coil.request.ImageRequest
 import com.skydoves.landscapist.CircularReveal
-import com.skydoves.landscapist.CircularRevealedImage
+import com.skydoves.landscapist.CircularRevealImage
 import com.skydoves.landscapist.ImageBySource
 import com.skydoves.landscapist.ImageLoad
 import com.skydoves.landscapist.ImageLoadState
@@ -491,7 +491,7 @@ public fun CoilImage(
           success.invoke(this, coilImageState)
         } else {
           val drawable = coilImageState.drawable ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = drawable.toBitmap().asImageBitmap(),
             bitmapPainter = rememberDrawablePainter(drawable = drawable),
@@ -600,7 +600,7 @@ public fun CoilImage(
           success.invoke(this, coilImageState)
         } else {
           val drawable = coilImageState.drawable ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = drawable.toBitmap().asImageBitmap(),
             bitmapPainter = rememberDrawablePainter(drawable = drawable),

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
@@ -41,7 +41,7 @@ import androidx.palette.graphics.Palette
 import com.facebook.common.executors.CallerThreadExecutor
 import com.facebook.imagepipeline.request.ImageRequest
 import com.skydoves.landscapist.CircularReveal
-import com.skydoves.landscapist.CircularRevealedImage
+import com.skydoves.landscapist.CircularRevealImage
 import com.skydoves.landscapist.ImageBySource
 import com.skydoves.landscapist.ImageLoad
 import com.skydoves.landscapist.ImageLoadState
@@ -314,7 +314,7 @@ public fun FrescoImage(
           success.invoke(this, frescoImageState)
         } else {
           val imageBitmap = frescoImageState.imageBitmap ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = imageBitmap,
             alignment = alignment,
@@ -421,7 +421,7 @@ public fun FrescoImage(
           success.invoke(this, frescoImageState)
         } else {
           val imageBitmap = frescoImageState.imageBitmap ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = imageBitmap,
             alignment = alignment,

--- a/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
+++ b/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
@@ -42,7 +42,7 @@ import androidx.palette.graphics.Palette
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.request.RequestOptions
 import com.skydoves.landscapist.CircularReveal
-import com.skydoves.landscapist.CircularRevealedImage
+import com.skydoves.landscapist.CircularRevealImage
 import com.skydoves.landscapist.ImageBySource
 import com.skydoves.landscapist.ImageLoad
 import com.skydoves.landscapist.ImageLoadState
@@ -161,7 +161,7 @@ public fun GlideImage(
  *     .apply(RequestOptions().diskCacheStrategy(DiskCacheStrategy.ALL))
  *     .thumbnail(0.6f)
  *     .transition(withCrossFade()),
- *   circularRevealedEnabled = true,
+ *   circularRevealEnabled = true,
  *   shimmerParams = ShimmerParams (
  *      baseColor = backgroundColor,
  *      highlightColor = highlightColor
@@ -337,7 +337,7 @@ public fun GlideImage(
           success.invoke(this, glideImageState)
         } else {
           val drawable = glideImageState.drawable ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = drawable.toBitmap().asImageBitmap(),
             bitmapPainter = rememberDrawablePainter(drawable),
@@ -456,7 +456,7 @@ public fun GlideImage(
           success.invoke(this, glideImageState)
         } else {
           val drawable = glideImageState.drawable ?: return@ImageRequest
-          CircularRevealedImage(
+          CircularRevealImage(
             modifier = Modifier.fillMaxSize(),
             bitmap = drawable.toBitmap().asImageBitmap(),
             bitmapPainter = rememberDrawablePainter(drawable),

--- a/landscapist/api/landscapist.api
+++ b/landscapist/api/landscapist.api
@@ -18,9 +18,9 @@ public abstract interface class com/skydoves/landscapist/CircularRevealFinishLis
 	public abstract fun onFinish ()V
 }
 
-public final class com/skydoves/landscapist/CircularRevealedImage {
-	public static final field DefaultCircularRevealedDuration I
-	public static final fun CircularRevealedImage (Landroidx/compose/ui/graphics/ImageBitmap;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;FLandroidx/compose/ui/graphics/ColorFilter;Lcom/skydoves/landscapist/CircularReveal;Landroidx/compose/runtime/Composer;II)V
+public final class com/skydoves/landscapist/CircularRevealImage {
+	public static final field DefaultCircularRevealDuration I
+	public static final fun CircularRevealImage (Landroidx/compose/ui/graphics/ImageBitmap;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;FLandroidx/compose/ui/graphics/ColorFilter;Lcom/skydoves/landscapist/CircularReveal;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/skydoves/landscapist/DrawablePainterKt {

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularReveal.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularReveal.kt
@@ -22,6 +22,6 @@ package com.skydoves.landscapist
  * @param duration milli-second times from start to finish animation.
  */
 public data class CircularReveal(
-  public val duration: Int = DefaultCircularRevealedDuration,
+  public val duration: Int = DefaultCircularRevealDuration,
   public val onFinishListener: CircularRevealFinishListener? = null
 )

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealAnimation.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealAnimation.kt
@@ -59,7 +59,7 @@ internal fun Painter.circularReveal(
   }
 
   return remember(this) {
-    CircularRevealedPainter(
+    CircularRevealPainter(
       imageBitmap = imageBitmap,
       painter = this
     )

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealImage.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealImage.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-@file:JvmName("CircularRevealedImage")
+@file:JvmName("CircularRevealImage")
 @file:JvmMultifileClass
 
 package com.skydoves.landscapist
@@ -31,7 +31,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 
 /**
- * CircularRevealedImage is an image composable for animating a clipping circle to reveal when loading an image.
+ * CircularRevealImage is an image composable for animating a clipping circle to reveal when loading an image.
  *
  * @param bitmap an image bitmap for loading for the content.
  * @param modifier adjust the drawing image layout or drawing decoration of the content.
@@ -46,7 +46,7 @@ import androidx.compose.ui.layout.ContentScale
  * @param circularReveal circular reveal parameters for running reveal animation when images are successfully loaded.
  */
 @Composable
-public fun CircularRevealedImage(
+public fun CircularRevealImage(
   bitmap: ImageBitmap,
   modifier: Modifier = Modifier,
   bitmapPainter: Painter = BitmapPainter(bitmap),
@@ -77,4 +77,4 @@ public fun CircularRevealedImage(
 }
 
 /** a definition of the default circular revealed animations duration. */
-public const val DefaultCircularRevealedDuration: Int = 350
+public const val DefaultCircularRevealDuration: Int = 350

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealPainter.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/CircularRevealPainter.kt
@@ -37,13 +37,13 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.core.util.Pools
 
 /**
- * CircularRevealedPainter is a [Painter] which animates a clipping circle to reveal an image.
+ * CircularRevealPainter is a [Painter] which animates a clipping circle to reveal an image.
  * Reveal animations provide users visual continuity when we show an image.
  *
  * @param imageBitmap an image bitmap for loading for the content.
  * @param painter an image painter to draw an [ImageBitmap] into the provided canvas.
  */
-internal class CircularRevealedPainter(
+internal class CircularRevealPainter(
   private val imageBitmap: ImageBitmap,
   private val painter: Painter
 ) : Painter() {


### PR DESCRIPTION
## Overview
Change the naming convention about `CircularRevelaed` to `CircularReveal`.