### PR TITLE
Bump Glide to 4.13.0 and AGP to 7.1.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext.versions = [
     versionCode      : 30,
     versionName      : '1.3.0',
 
-    gradleBuildTool  : '7.0.2',
+    gradleBuildTool  : '7.1.0',
     spotlessGradle   : '6.2.1',
     dokkaGradle      : '1.6.0',
     binaryValidator  : '0.8.0',
@@ -23,7 +23,7 @@ ext.versions = [
     multidex         : '2.0.1',
 
     frescoVersion    : '2.6.0',
-    glideVersion     : '4.12.0',
+    glideVersion     : '4.13.0',
     coilVersion      : '1.4.0',
 
     paletteVersion   : '1.0.0',


### PR DESCRIPTION
## Overview
Bump Glide to `4.13.0` and AGP to `7.1.0`.