### PR TITLE
Replace BoxWithConstraints with Box

### DIFF
--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/ImageLoad.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/ImageLoad.kt
@@ -19,8 +19,8 @@
 
 package com.skydoves.landscapist
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -31,7 +31,6 @@ import androidx.compose.ui.Modifier
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -61,7 +60,7 @@ public fun <T : Any> ImageLoad(
       state = it
     }
   }
-  BoxWithConstraints(modifier) {
+  Box(modifier) {
     content(state)
   }
 }

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/Shimmer.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/Shimmer.kt
@@ -27,7 +27,7 @@ import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -78,7 +78,7 @@ public fun Shimmer(
     )
   }
 
-  BoxWithConstraints(modifier) {
+  Box(modifier) {
 
     Canvas(Modifier.fillMaxSize()) {
       val paint = paintPool.acquire() ?: Paint()


### PR DESCRIPTION
`BoxWithConstraints` uses subcomposition to layout, which is slower.

If you aren't using the constraints then you are paying a performance hit for no reason compared with using a plain `Box`.

If I have missed a reason then please let me know! I thought I would just contribute a quick fix for you though, tested it out and everything seems to still work fine.
