### PR TITLE
Restrict API accessibilities by annotating with InternalLandscapistApi

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/KotlinAndroid.kt
@@ -45,7 +45,8 @@ internal fun Project.configureKotlinAndroid(
       jvmTarget = libs.findVersion("jvmTarget").get().toString()
       freeCompilerArgs = freeCompilerArgs + listOf(
         "-opt-in=kotlin.RequiresOptIn",
-        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
+        "-opt-in=com.skydoves.landscapist.InternalLandscapistApi",
       )
     }
 

--- a/landscapist/api/landscapist.api
+++ b/landscapist/api/landscapist.api
@@ -58,6 +58,9 @@ public final class com/skydoves/landscapist/ImageWithSource {
 	public static final fun ImageBySource (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;Landroidx/compose/ui/graphics/ColorFilter;FLandroidx/compose/runtime/Composer;II)V
 }
 
+public abstract interface annotation class com/skydoves/landscapist/InternalLandscapistApi : java/lang/annotation/Annotation {
+}
+
 public final class com/skydoves/landscapist/RememberPainterPluginsKt {
 	public static final fun rememberBitmapPainter (Ljava/util/List;Landroidx/compose/ui/graphics/ImageBitmap;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
 	public static final fun rememberDrawablePainter (Landroid/graphics/drawable/Drawable;Ljava/util/List;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;

--- a/landscapist/api/landscapist.api
+++ b/landscapist/api/landscapist.api
@@ -138,7 +138,3 @@ public abstract interface class com/skydoves/landscapist/plugins/ImagePlugin$Suc
 	public abstract fun compose (Landroidx/compose/runtime/Composer;I)Lcom/skydoves/landscapist/plugins/ImagePlugin;
 }
 
-public final class com/skydoves/landscapist/plugins/ImagePluginKt {
-	public static final fun composePlugins (Landroidx/compose/ui/graphics/painter/Painter;Ljava/util/List;Landroidx/compose/ui/graphics/ImageBitmap;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
-}
-

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/InternalLandscapistApi.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/InternalLandscapistApi.kt
@@ -1,0 +1,30 @@
+/*
+ * Designed and developed by 2020-2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist
+
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.PROPERTY,
+  AnnotationTarget.CONSTRUCTOR,
+  AnnotationTarget.FUNCTION,
+  AnnotationTarget.TYPEALIAS
+)
+@RequiresOptIn(
+  message = "This is internal API for the landscapist libraries. Do not depend on " +
+    "this API in your own client code.",
+  level = RequiresOptIn.Level.ERROR
+)
+public annotation class InternalLandscapistApi

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/RememberPainterPlugins.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/RememberPainterPlugins.kt
@@ -43,6 +43,7 @@ import com.skydoves.landscapist.plugins.composePlugins
  * @param imagePlugins A list of [ImagePlugin] that will be applied to the drawable painter.
  */
 @Composable
+@InternalLandscapistApi
 public fun rememberDrawablePainter(
   drawable: Drawable,
   imagePlugins: List<ImagePlugin>
@@ -64,6 +65,7 @@ public fun rememberDrawablePainter(
  * @param imagePlugins A list of [ImagePlugin] that will be applied to the drawable painter.
  */
 @Composable
+@InternalLandscapistApi
 public fun rememberBitmapPainter(
   imagePlugins: List<ImagePlugin>,
   imageBitmap: ImageBitmap

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/components/ImageComponentExtensions.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/components/ImageComponentExtensions.kt
@@ -16,6 +16,7 @@
 package com.skydoves.landscapist.components
 
 import androidx.compose.runtime.Composable
+import com.skydoves.landscapist.InternalLandscapistApi
 import com.skydoves.landscapist.plugins.ImagePlugin
 
 /**
@@ -29,30 +30,27 @@ public inline val ImageComponent.imagePlugins: List<ImagePlugin>
     emptyList()
   }
 
-/**
- * Runs image plugins from the given [ImageComponent] that will be run in a loading state.
- */
+/** Runs image plugins from the given [ImageComponent] that will be run in a loading state. */
 @Composable
+@InternalLandscapistApi
 public fun ImageComponent.ComposeLoadingStatePlugins() {
   imagePlugins.filterIsInstance<ImagePlugin.LoadingStatePlugin>().forEach { plugin ->
     plugin.compose()
   }
 }
 
-/**
- * Runs image plugins from the given [ImageComponent] that will be run in a success state.
- */
+/** Runs image plugins from the given [ImageComponent] that will be run in a success state. */
 @Composable
+@InternalLandscapistApi
 public fun ImageComponent.ComposeSuccessStatePlugins() {
   imagePlugins.filterIsInstance<ImagePlugin.SuccessStatePlugin>().forEach { plugin ->
     plugin.compose()
   }
 }
 
-/**
- * Runs image plugins from the given [ImageComponent] that will be run in a failure state.
- */
+/** Runs image plugins from the given [ImageComponent] that will be run in a failure state. */
 @Composable
+@InternalLandscapistApi
 public fun ImageComponent.ComposeFailureStatePlugins() {
   imagePlugins.filterIsInstance<ImagePlugin.FailureStatePlugin>().forEach { plugin ->
     plugin.compose()

--- a/landscapist/src/main/kotlin/com/skydoves/landscapist/plugins/ImagePlugin.kt
+++ b/landscapist/src/main/kotlin/com/skydoves/landscapist/plugins/ImagePlugin.kt
@@ -67,7 +67,7 @@ public sealed interface ImagePlugin {
  * @param imageBitmap A target [imageBitmap] to be composed of the given [Painter]
  */
 @Composable
-public fun Painter.composePlugins(
+internal fun Painter.composePlugins(
   imagePlugins: List<ImagePlugin>,
   imageBitmap: ImageBitmap
 ): Painter {


### PR DESCRIPTION
### 🎯 Goal
Restrict API accessibility by annotating with InternalLandscapistApi.