### PR TITLE
Fresco: honor CloseableReference and properly close it

### DIFF
--- a/fresco/api/fresco.api
+++ b/fresco/api/fresco.api
@@ -47,7 +47,7 @@ public final class com/skydoves/landscapist/fresco/FrescoImageState$Success : co
 }
 
 public final class com/skydoves/landscapist/fresco/FrescoImageStateKt {
-	public static final fun toFrescoImageState (Lcom/skydoves/landscapist/ImageLoadState;)Lcom/skydoves/landscapist/fresco/FrescoImageState;
+	public static final fun toFrescoImageState (Lcom/skydoves/landscapist/ImageLoadState;Landroidx/compose/runtime/Composer;I)Lcom/skydoves/landscapist/fresco/FrescoImageState;
 }
 
 public final class com/skydoves/landscapist/fresco/LocalFrescoProviderKt {

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
@@ -16,7 +16,6 @@
 package com.skydoves.landscapist.fresco
 
 import android.graphics.Bitmap
-import androidx.compose.ui.graphics.asImageBitmap
 import com.facebook.common.references.CloseableReference
 import com.facebook.datasource.DataSource
 import com.facebook.drawee.backends.pipeline.info.ImageOrigin
@@ -39,7 +38,7 @@ internal class FlowBaseBitmapDataSubscriber : BaseBitmapReferenceDataSubscriber(
 
   override fun onNewResultImpl(bitmapReference: CloseableReference<Bitmap>?) {
     this.internalStateFlow.value = ImageLoadState.Success(
-      data = bitmapReference?.get()?.asImageBitmap(),
+      data = bitmapReference?.cloneOrNull(),
       dataSource = imageOrigin.toDataSource()
     )
   }

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImageState.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImageState.kt
@@ -15,8 +15,11 @@
  */
 package com.skydoves.landscapist.fresco
 
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import com.facebook.common.references.CloseableReference
 import com.facebook.datasource.DataSource
 import com.facebook.imagepipeline.image.CloseableImage
@@ -53,14 +56,21 @@ public sealed class FrescoImageState : ImageState {
 
 /** casts an [ImageLoadState] type to a [FrescoImageState]. */
 @Suppress("UNCHECKED_CAST")
+@Composable
 public fun ImageLoadState.toFrescoImageState(): FrescoImageState {
   return when (this) {
     is ImageLoadState.None -> FrescoImageState.None
     is ImageLoadState.Loading -> FrescoImageState.Loading
-    is ImageLoadState.Success -> FrescoImageState.Success(
-      imageBitmap = data as? ImageBitmap,
-      dataSource = dataSource
-    )
+    is ImageLoadState.Success -> {
+      val bitmapRef = data as? CloseableReference<Bitmap>
+      val imageBitmap = if (bitmapRef != null) {
+        rememberCloseableRef(bitmapRef).asImageBitmap()
+      } else null
+      FrescoImageState.Success(
+        imageBitmap = imageBitmap,
+        dataSource = dataSource
+      )
+    }
     is ImageLoadState.Failure -> FrescoImageState.Failure(
       dataSource = data as? DataSource<CloseableReference<CloseableImage>>,
       reason = reason

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/RememberCloseableRef.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/RememberCloseableRef.kt
@@ -1,0 +1,52 @@
+/*
+ * Designed and developed by 2020-2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.fresco
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.RememberObserver
+import androidx.compose.runtime.remember
+import com.facebook.common.references.CloseableReference
+
+/**
+ * Remember the given [CloseableReference] in the current composition.
+ *
+ * The [CloseableReference] will be closed when the object leaves the composition.
+ *
+ * @param ref the [CloseableReference] to be remembered
+ * @return the value contained in the reference, as per [CloseableReference.get]
+ */
+@Composable
+internal fun <T> rememberCloseableRef(ref: CloseableReference<T>): T {
+  return remember(ref) { CloseableRefObserver(ref) }.value
+}
+
+private class CloseableRefObserver<T>(val ref: CloseableReference<T>) : RememberObserver {
+
+  val value: T
+    get() = ref.get()
+
+  override fun onRemembered() {
+    // nothing to do
+  }
+
+  override fun onAbandoned() {
+    ref.close()
+  }
+
+  override fun onForgotten() {
+    ref.close()
+  }
+}


### PR DESCRIPTION
fixes #194

### 🎯 Goal

Make FrescoImage more stable with respect to premature recycling of bitmaps that are still in use. Avoid app crashes due to displaying a recycled bitmap.

### 🛠 Implementation details

See suggested fix in #194 
