### PR TITLE
Dispose datasource subscriber for Fresco onDispose 

### DIFF
--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
@@ -36,7 +36,11 @@ internal class FlowBaseBitmapDataSubscriber : BaseBitmapReferenceDataSubscriber(
 
   private var imageOrigin: Int = ImageOrigin.UNKNOWN
 
+  private var successBitmapReference: CloseableReference<Bitmap>? = null
+  private var failureBitmapReference: DataSource<CloseableReference<CloseableImage>>? = null
+
   override fun onNewResultImpl(bitmapReference: CloseableReference<Bitmap>?) {
+    this.successBitmapReference = bitmapReference
     this.internalStateFlow.value = ImageLoadState.Success(
       data = bitmapReference?.cloneOrNull(),
       dataSource = imageOrigin.toDataSource()
@@ -44,6 +48,7 @@ internal class FlowBaseBitmapDataSubscriber : BaseBitmapReferenceDataSubscriber(
   }
 
   override fun onFailureImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
+    this.failureBitmapReference = dataSource
     this.internalStateFlow.value = ImageLoadState.Failure(
       data = dataSource,
       reason = dataSource.failureCause
@@ -56,6 +61,11 @@ internal class FlowBaseBitmapDataSubscriber : BaseBitmapReferenceDataSubscriber(
     if (internalStateFlow.value == ImageLoadState.None) {
       this.internalStateFlow.value = ImageLoadState.Loading
     }
+  }
+
+  fun clearBitmapResource() {
+    successBitmapReference?.close()
+    failureBitmapReference?.close()
   }
 
   fun updateImageOrigin(imageOrigin: Int) {

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -233,4 +234,8 @@ private fun FrescoImage(
     modifier = modifier,
     content = content
   )
+
+  DisposableEffect(key1 = recomposeKey) {
+    onDispose { subscriber.clearBitmapResource() }
+  }
 }


### PR DESCRIPTION
### 🎯 Goal
Dispose datasource subscriber for Fresco onDispose.