### PR TITLE
Close bitmapReference and dataSource safely for Fresco

### DIFF
--- a/fresco/api/fresco.api
+++ b/fresco/api/fresco.api
@@ -15,13 +15,13 @@ public abstract class com/skydoves/landscapist/fresco/FrescoImageState : com/sky
 
 public final class com/skydoves/landscapist/fresco/FrescoImageState$Failure : com/skydoves/landscapist/fresco/FrescoImageState {
 	public static final field $stable I
-	public fun <init> (Lcom/facebook/datasource/DataSource;Ljava/lang/Throwable;)V
-	public final fun component1 ()Lcom/facebook/datasource/DataSource;
+	public fun <init> (Lcom/facebook/imagepipeline/image/CloseableImage;Ljava/lang/Throwable;)V
+	public final fun component1 ()Lcom/facebook/imagepipeline/image/CloseableImage;
 	public final fun component2 ()Ljava/lang/Throwable;
-	public final fun copy (Lcom/facebook/datasource/DataSource;Ljava/lang/Throwable;)Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;
-	public static synthetic fun copy$default (Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;Lcom/facebook/datasource/DataSource;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;
+	public final fun copy (Lcom/facebook/imagepipeline/image/CloseableImage;Ljava/lang/Throwable;)Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;
+	public static synthetic fun copy$default (Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;Lcom/facebook/imagepipeline/image/CloseableImage;Ljava/lang/Throwable;ILjava/lang/Object;)Lcom/skydoves/landscapist/fresco/FrescoImageState$Failure;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getDataSource ()Lcom/facebook/datasource/DataSource;
+	public final fun getCloseableImage ()Lcom/facebook/imagepipeline/image/CloseableImage;
 	public final fun getReason ()Ljava/lang/Throwable;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FlowBaseBitmapDataSubscriber.kt
@@ -41,13 +41,15 @@ internal class FlowBaseBitmapDataSubscriber : BaseBitmapReferenceDataSubscriber(
       data = bitmapReference?.cloneOrNull(),
       dataSource = imageOrigin.toDataSource()
     )
+    CloseableReference.closeSafely(bitmapReference)
   }
 
   override fun onFailureImpl(dataSource: DataSource<CloseableReference<CloseableImage>>) {
     this.internalStateFlow.value = ImageLoadState.Failure(
-      data = dataSource,
+      data = dataSource.result?.cloneOrNull(),
       reason = dataSource.failureCause
     )
+    dataSource.close()
   }
 
   override fun onProgressUpdate(dataSource: DataSource<CloseableReference<CloseableImage>>) {


### PR DESCRIPTION
### 🎯 Goal
Close bitmapReference and dataSource safely for Fresco.