### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ Landscapist supports preview mode for each image library; **Glide**, **Coil**, a
 GlideImage(
   imageModel = { imageUrl },
   modifier = Modifier.aspectRatio(0.8f),
-  previewPlaceholder = R.drawable.poster
+  previewPlaceholder = painterResource(id = R.drawable.poster)
 )
 ```
 > **Note**: You can also use the the `previewPlaceholder` parameter for **`CoilImage`** and **`FrescoImage`**.


### PR DESCRIPTION
Update GlideImage previewPlaceholder

### 🎯 Goal
Update README.md

### 🛠 Implementation details
```kotlin
previewPlaceholder = painterResource(id = R.drawable.poster)
```

### ✍️ Explain examples
The parameter previewPlaceholder in GlideImage is a Painter, so we should use the painterResource.

