### PR TITLE
Migrate to use androidx.lifecycle.compose.LocalLifecycleOwner

### DIFF
--- a/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
+++ b/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
@@ -34,10 +34,10 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntSize
 import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import coil.ImageLoader
 import coil.request.ImageRequest
 import coil.request.ImageResult

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
@@ -245,7 +245,7 @@ private fun FrescoImage(
       suspendCancellableCoroutine { cont ->
         datasource.subscribe(subscriber, CallerThreadExecutor.getInstance())
 
-        cont.resume(subscriber.imageLoadStateFlow) {
+        cont.resume(subscriber.imageLoadStateFlow) { cause, _, _ ->
           // close the fresco datasource request if cancelled.
           datasource.close()
         }


### PR DESCRIPTION
Migrate to use androidx.lifecycle.compose.LocalLifecycleOwner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated lifecycle owner integration to align with the latest Compose libraries, ensuring improved compatibility without altering behavior.
* **Chores**
  * Adjusted cancellation handling to match updated coroutine APIs, preserving existing functionality while improving consistency with modern conventions.
  * General maintenance to keep image-loading components current with upstream dependencies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->