### PR TITLE
Migrate to use rememberTransition

### DIFF
--- a/landscapist-animation/src/commonMain/kotlin/com/skydoves/landscapist/animation/crossfade/CrossfadeTransition.kt
+++ b/landscapist-animation/src/commonMain/kotlin/com/skydoves/landscapist/animation/crossfade/CrossfadeTransition.kt
@@ -17,8 +17,8 @@ package com.skydoves.landscapist.animation.crossfade
 
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.State
@@ -43,9 +43,9 @@ internal fun updateFadeInTransition(key: Any, durationMs: Int): FadeInTransition
   }
 
   // Our actual transition, which reads our transitionState
-  val transition = updateTransition(
-    transitionState = transitionState,
-    label = "Image fadeIn",
+  val transition = rememberTransition(
+    transitionState,
+    "Image fadeIn",
   )
 
   // Alpha animates over the first 50%

--- a/landscapist-placeholder/src/commonMain/kotlin/com/skydoves/landscapist/placeholder/shimmer/Placeholder.kt
+++ b/landscapist-placeholder/src/commonMain/kotlin/com/skydoves/landscapist/placeholder/shimmer/Placeholder.kt
@@ -20,8 +20,8 @@ import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.Transition
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.rememberTransition
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.updateTransition
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -107,7 +107,7 @@ internal fun Modifier.placeholder(
   val transitionState = remember { MutableTransitionState(visible) }.apply {
     targetState = visible
   }
-  val transition = updateTransition(transitionState, "placeholder_crossfade")
+  val transition = rememberTransition(transitionState, "placeholder_crossfade")
 
   val placeholderAlpha by transition.animateFloat(
     transitionSpec = placeholderFadeTransitionSpec,


### PR DESCRIPTION
Migrate to use rememberTransition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized animation handling by switching to a new transition API for fade-in and placeholder crossfade effects.
  * Maintains the same visual behavior (alpha, brightness, saturation animations) with no changes to public APIs.
  * Internal improvements only; no user action required.
  * Aligns implementation with current framework recommendations while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->