### PR TITLE
Fix key as a state for cross fade animations

### DIFF
--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/FadeInEffectNode.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/FadeInEffectNode.kt
@@ -17,6 +17,9 @@ package com.skydoves.landscapist.crossfade
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.toRect
@@ -32,7 +35,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 private class FadeInEffectNode(
-  var key: Any,
+  var key: State<Any>,
   var durationMs: Int,
 ) : Modifier.Node(), DrawModifierNode {
 
@@ -89,7 +92,7 @@ private class FadeInEffectNode(
 }
 
 private data class FadeInEffectElement(
-  val key: Any,
+  val key: State<Any>,
   val durationMs: Int,
 ) : ModifierNodeElement<FadeInEffectNode>() {
 
@@ -104,11 +107,13 @@ private data class FadeInEffectElement(
 
   override fun InspectorInfo.inspectableProperties() {
     name = "fadeInWithEffect"
-    properties["key"] = key
+    properties["key"] = key.value
     properties["durationMs"] = durationMs
   }
 }
 
+@Composable
 internal fun Modifier.fadeInWithEffect(key: Any, durationMs: Int): Modifier {
-  return this.then(FadeInEffectElement(key, durationMs))
+  val state: State<Any> = mutableStateOf(key)
+  return this.then(FadeInEffectElement(state, durationMs))
 }

--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/FadeOutEffectNode.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/FadeOutEffectNode.kt
@@ -17,6 +17,9 @@ package com.skydoves.landscapist.crossfade
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.toRect
@@ -32,7 +35,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 private class FadeOutEffectNode(
-  var key: Any,
+  var key: State<Any>,
   var durationMs: Int,
 ) : Modifier.Node(), DrawModifierNode {
 
@@ -86,7 +89,7 @@ private class FadeOutEffectNode(
 }
 
 private data class FadeOutEffectElement(
-  val key: Any,
+  val key: State<Any>,
   val durationMs: Int,
 ) : ModifierNodeElement<FadeOutEffectNode>() {
 
@@ -101,11 +104,13 @@ private data class FadeOutEffectElement(
 
   override fun InspectorInfo.inspectableProperties() {
     name = "fadeOutWithEffect"
-    properties["key"] = key
+    properties["key"] = key.value
     properties["durationMs"] = durationMs
   }
 }
 
+@Composable
 internal fun Modifier.fadeOutWithEffect(key: Any, durationMs: Int): Modifier {
-  return this.then(FadeOutEffectElement(key, durationMs))
+  val state: State<Any> = mutableStateOf(key)
+  return this.then(FadeOutEffectElement(state, durationMs))
 }


### PR DESCRIPTION
Fix the key as a state for cross-fade animations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reworked fade-in and fade-out effects to use state-backed keys, improving observation of key changes without altering public APIs.

* **Bug Fixes**
  * Animations respond more reliably when keys update, reducing missed or stale transitions during crossfades and improving overall stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->