### PR TITLE
Rename the render script library to landscapist-renderscript-toolkit

### DIFF
--- a/landscapist-transformation/src/main/cpp/CMakeLists.txt
+++ b/landscapist-transformation/src/main/cpp/CMakeLists.txt
@@ -59,7 +59,7 @@ endif ()
 # Gradle automatically packages shared libraries with your APK.
 
 add_library(# Sets the name of the library.
-        renderscript-toolkit
+        landscapist-renderscript-toolkit
         # Sets the library as a shared library.
         SHARED
         # Provides a relative path to your source file(s).
@@ -88,7 +88,7 @@ find_library(# Sets the name of the path variable.
 # build script, prebuilt third-party libraries, or system libraries.
 
 target_link_libraries(# Specifies the target library.
-        renderscript-toolkit
+        landscapist-renderscript-toolkit
 
         cpufeatures
         jnigraphics

--- a/landscapist-transformation/src/main/kotlin/com/skydoves/landscapist/transformation/RenderScriptToolkit.kt
+++ b/landscapist-transformation/src/main/kotlin/com/skydoves/landscapist/transformation/RenderScriptToolkit.kt
@@ -280,7 +280,7 @@ internal object RenderScriptToolkit {
   private var nativeHandle: Long = 0
 
   init {
-    System.loadLibrary("renderscript-toolkit")
+    System.loadLibrary("landscapist-renderscript-toolkit")
     nativeHandle = createNative()
   }
 


### PR DESCRIPTION
Rename the render script library to landscapist-renderscript-toolkit.

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```bash
$ ./gradlew spotlessApply
```

Then dump binary API of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that make this change binary incompatible.

```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the underlying native library to align with module naming and branding.
  * No functional changes or API updates; existing integrations continue to work without modification.
  * Improves clarity and consistency for dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->