### PR TITLE
Separate loading keys from the image options

### DIFF
--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/ImageOptions.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/ImageOptions.kt
@@ -50,7 +50,28 @@ public data class ImageOptions(
   public val isValidSize: Boolean
     inline get() = requestSize.width > 0 && requestSize.height > 0
 
+  /**
+   * Returns a key that represents only the loading-related properties.
+   * This key should be used for image loading decisions to prevent unnecessary reloads
+   * when only rendering properties (colorFilter, alpha, alignment, contentScale, contentDescription) change.
+   */
+  @InternalLandscapistApi
+  public val loadingOptionsKey: Any
+    get() = LoadingOptionsKey(requestSize = requestSize, tag = tag)
+
   private companion object {
     const val DEFAULT_IMAGE_SIZE: Int = -1
   }
 }
+
+/**
+ * Internal data class that holds only the loading-related properties of [ImageOptions].
+ * Used as a stable key for image loading operations to prevent unnecessary reloads
+ * when only rendering properties change.
+ */
+@InternalLandscapistApi
+@Immutable
+public data class LoadingOptionsKey(
+  public val requestSize: IntSize,
+  public val tag: String,
+)


### PR DESCRIPTION
Separate loading keys from the image options (#705)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading-specific key control to fine-tune image loading behavior.

* **Improvements**
  * Enhanced state management to prevent unnecessary image reloads when rendering properties change, improving performance and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->