### PR TITLE
Treat ImageState.NONE as same as ImageState.LOADING

### DIFF
--- a/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
+++ b/coil/src/main/kotlin/com/skydoves/landscapist/coil/CoilImage.kt
@@ -232,9 +232,9 @@ public fun CoilImage(
       enabled = crossfadePlugin != null,
     ) {
       when (coilImageState) {
-        is CoilImageState.None -> Unit
-
-        is CoilImageState.Loading -> {
+        is CoilImageState.None,
+        is CoilImageState.Loading,
+        -> {
           component.ComposeLoadingStatePlugins(
             modifier = Modifier.constraint(this),
             imageOptions = imageOptions,
@@ -247,7 +247,7 @@ public fun CoilImage(
               )
             },
           )
-          loading?.invoke(this, coilImageState)
+          loading?.invoke(this, CoilImageState.Loading)
         }
 
         is CoilImageState.Failure -> {

--- a/coil3/src/commonMain/kotlin/com/skydoves/landscapist/coil3/CoilImage.kt
+++ b/coil3/src/commonMain/kotlin/com/skydoves/landscapist/coil3/CoilImage.kt
@@ -210,9 +210,9 @@ public fun CoilImage(
       enabled = crossfadePlugin != null,
     ) {
       when (coilImageState) {
-        is CoilImageState.None -> Unit
-
-        is CoilImageState.Loading -> {
+        is CoilImageState.None,
+        is CoilImageState.Loading,
+        -> {
           component.ComposeLoadingStatePlugins(
             modifier = Modifier.constraint(this),
             imageOptions = imageOptions,
@@ -225,7 +225,7 @@ public fun CoilImage(
               )
             },
           )
-          loading?.invoke(this, coilImageState)
+          loading?.invoke(this, CoilImageState.Loading)
         }
 
         is CoilImageState.Failure -> {

--- a/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
+++ b/fresco/src/main/kotlin/com/skydoves/landscapist/fresco/FrescoImage.kt
@@ -140,9 +140,9 @@ public fun FrescoImage(
       }
 
       when (frescoImageState) {
-        is FrescoImageState.None -> Unit
-
-        is FrescoImageState.Loading -> {
+        is FrescoImageState.None,
+        is FrescoImageState.Loading,
+        -> {
           component.ComposeLoadingStatePlugins(
             modifier = Modifier.constraint(this),
             imageOptions = imageOptions,
@@ -155,7 +155,7 @@ public fun FrescoImage(
               )
             },
           )
-          loading?.invoke(this, frescoImageState)
+          loading?.invoke(this, FrescoImageState.Loading)
         }
 
         is FrescoImageState.Failure -> {

--- a/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
+++ b/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
@@ -168,9 +168,9 @@ public fun GlideImage(
       }
 
       when (glideImageState) {
-        is GlideImageState.None -> Unit
-
-        is GlideImageState.Loading -> {
+        is GlideImageState.None,
+        is GlideImageState.Loading,
+        -> {
           component.ComposeLoadingStatePlugins(
             modifier = Modifier.constraint(this),
             imageOptions = imageOptions,
@@ -185,7 +185,7 @@ public fun GlideImage(
               )
             },
           )
-          loading?.invoke(this, glideImageState)
+          loading?.invoke(this, GlideImageState.Loading)
         }
 
         is GlideImageState.Failure -> {

--- a/landscapist/api/android/landscapist.api
+++ b/landscapist/api/android/landscapist.api
@@ -89,6 +89,7 @@ public final class com/skydoves/landscapist/ImageOptions {
 	public final fun getColorFilter ()Landroidx/compose/ui/graphics/ColorFilter;
 	public final fun getContentDescription ()Ljava/lang/String;
 	public final fun getContentScale ()Landroidx/compose/ui/layout/ContentScale;
+	public final fun getLoadingOptionsKey ()Ljava/lang/Object;
 	public final fun getRequestSize-YbymL2g ()J
 	public final fun getTag ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -104,6 +105,20 @@ public abstract interface annotation class com/skydoves/landscapist/InternalLand
 
 public final class com/skydoves/landscapist/LandscapistImageKt {
 	public static final fun LandscapistImage (Lcom/skydoves/landscapist/ImageOptions;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/skydoves/landscapist/LoadingOptionsKey {
+	public static final field $stable I
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-YbymL2g ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-viCIZxY (JLjava/lang/String;)Lcom/skydoves/landscapist/LoadingOptionsKey;
+	public static synthetic fun copy-viCIZxY$default (Lcom/skydoves/landscapist/LoadingOptionsKey;JLjava/lang/String;ILjava/lang/Object;)Lcom/skydoves/landscapist/LoadingOptionsKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestSize-YbymL2g ()J
+	public final fun getTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/skydoves/landscapist/RememberDrawablePainterKt {

--- a/landscapist/api/desktop/landscapist.api
+++ b/landscapist/api/desktop/landscapist.api
@@ -85,6 +85,7 @@ public final class com/skydoves/landscapist/ImageOptions {
 	public final fun getColorFilter ()Landroidx/compose/ui/graphics/ColorFilter;
 	public final fun getContentDescription ()Ljava/lang/String;
 	public final fun getContentScale ()Landroidx/compose/ui/layout/ContentScale;
+	public final fun getLoadingOptionsKey ()Ljava/lang/Object;
 	public final fun getRequestSize-YbymL2g ()J
 	public final fun getTag ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -100,6 +101,20 @@ public abstract interface annotation class com/skydoves/landscapist/InternalLand
 
 public final class com/skydoves/landscapist/LandscapistImageKt {
 	public static final fun LandscapistImage (Lcom/skydoves/landscapist/ImageOptions;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class com/skydoves/landscapist/LoadingOptionsKey {
+	public static final field $stable I
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-YbymL2g ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-viCIZxY (JLjava/lang/String;)Lcom/skydoves/landscapist/LoadingOptionsKey;
+	public static synthetic fun copy-viCIZxY$default (Lcom/skydoves/landscapist/LoadingOptionsKey;JLjava/lang/String;ILjava/lang/Object;)Lcom/skydoves/landscapist/LoadingOptionsKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestSize-YbymL2g ()J
+	public final fun getTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/skydoves/landscapist/RememberPainterPluginsKt {

--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/ImageLoad.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/ImageLoad.kt
@@ -94,7 +94,9 @@ public fun <T : Any> ImageLoad(
 private fun executeImageLoading(
   executeImageRequest: suspend () -> Flow<ImageLoadState>,
 ) = flow {
-  // execute imager loading
+  // emit loading state
+  emit(ImageLoadState.Loading)
+  // execute image loading
   emitAll(executeImageRequest())
 }.catch {
   // emit a failure loading state


### PR DESCRIPTION
Treat ImageState.NONE as same as ImageState.LOADING.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced LoadingOptionsKey API class with support for request size and tag properties, plus new getLoadingOptionsKey() method on ImageOptions

* **Bug Fixes**
  * Normalized loading state transitions across image loading libraries for improved consistency
  * Enhanced image loading flow to emit an initial Loading state before delegating to underlying request processing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->