### PR TITLE
Calculate aspectRatio for Sub-sampling to prevent ANR in unbounded sizes

### DIFF
--- a/app/src/main/kotlin/com/github/skydoves/landscapistdemo/ui/MainPosters.kt
+++ b/app/src/main/kotlin/com/github/skydoves/landscapistdemo/ui/MainPosters.kt
@@ -150,7 +150,6 @@ private fun SelectedPoster(
 
   LandscapistImage(
     imageModel = { poster.image },
-    imageOptions = ImageOptions(),
     modifier = Modifier.aspectRatio(0.75f),
     component = rememberImageComponent {
       +ShimmerPlugin(

--- a/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/subsampling/SubSamplingImage.kt
+++ b/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/subsampling/SubSamplingImage.kt
@@ -16,6 +16,7 @@
 package com.skydoves.landscapist.zoomable.subsampling
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -85,8 +86,25 @@ public fun SubSamplingImage(
       }
   }
 
+  // Calculate aspect ratio from image size to constrain layout
+  // This prevents ANR when height is unbounded (e.g., Modifier.fillMaxWidth())
+  val aspectRatio = remember(imageSize) {
+    if (imageSize.width > 0 && imageSize.height > 0) {
+      imageSize.width.toFloat() / imageSize.height.toFloat()
+    } else {
+      null
+    }
+  }
+
   Canvas(
     modifier = modifier
+      .then(
+        if (aspectRatio != null) {
+          Modifier.aspectRatio(aspectRatio)
+        } else {
+          Modifier
+        },
+      )
       .fillMaxSize()
       .clipToBounds()
       .onSizeChanged { size ->


### PR DESCRIPTION
Calculate aspectRatio for Sub-sampling to prevent ANR in unbounded sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shimmer animation during image loading
  * Enhanced image aspect ratio handling for improved layout rendering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->