### PR TITLE
Use Modifier.fillMaxSize for the LandscapistImage

### DIFF
--- a/landscapist-image/src/commonMain/kotlin/com/skydoves/landscapist/image/LandscapistImage.kt
+++ b/landscapist-image/src/commonMain/kotlin/com/skydoves/landscapist/image/LandscapistImage.kt
@@ -18,6 +18,7 @@ package com.skydoves.landscapist.image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -165,7 +166,7 @@ public fun LandscapistImage(
                 success.invoke(this, state, painter)
               } else {
                 DefaultSuccessContent(
-                  modifier = Modifier,
+                  modifier = Modifier.fillMaxSize(),
                   painter = painter,
                   imageOptions = imageOptions,
                 )

--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/CrossfadeWithEffect.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/CrossfadeWithEffect.kt
@@ -61,7 +61,7 @@ public fun <T> CrossfadeWithEffect(
     }
   }
 
-  Box(modifier, propagateMinConstraints = true) {
+  Box(modifier) {
     if (enabled) {
       currentlyVisibleItems.forEach { state ->
         key(contentKey(state)) {
@@ -80,7 +80,7 @@ public fun <T> CrossfadeWithEffect(
             }
           }
 
-          Box(modifier = animationModifier, propagateMinConstraints = true) {
+          Box(modifier = animationModifier) {
             content(state)
           }
         }


### PR DESCRIPTION
Use Modifier.fillMaxSize for the LandscapistImage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sizing behavior of images when displayed with default content.
  * Refined layout constraint handling during crossfade animations for enhanced visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->