### PR TITLE
Track the original width/height sizes for the cached image

### DIFF
--- a/landscapist-core/api/android/landscapist-core.api
+++ b/landscapist-core/api/android/landscapist-core.api
@@ -274,15 +274,22 @@ public final class com/skydoves/landscapist/core/cache/CacheKey$Companion {
 }
 
 public final class com/skydoves/landscapist/core/cache/CachedImage {
-	public fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;J)V
+	public fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Lcom/skydoves/landscapist/core/model/DataSource;
 	public final fun component3 ()J
-	public final fun copy (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;J)Lcom/skydoves/landscapist/core/cache/CachedImage;
-	public static synthetic fun copy$default (Lcom/skydoves/landscapist/core/cache/CachedImage;Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JILjava/lang/Object;)Lcom/skydoves/landscapist/core/cache/CachedImage;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;)Lcom/skydoves/landscapist/core/cache/CachedImage;
+	public static synthetic fun copy$default (Lcom/skydoves/landscapist/core/cache/CachedImage;Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;ILjava/lang/Object;)Lcom/skydoves/landscapist/core/cache/CachedImage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
 	public final fun getDataSource ()Lcom/skydoves/landscapist/core/model/DataSource;
+	public final fun getDiskCachePath ()Ljava/lang/String;
+	public final fun getOriginalHeight ()I
+	public final fun getOriginalWidth ()I
 	public final fun getSizeBytes ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/landscapist-core/api/desktop/landscapist-core.api
+++ b/landscapist-core/api/desktop/landscapist-core.api
@@ -264,15 +264,22 @@ public final class com/skydoves/landscapist/core/cache/CacheKey$Companion {
 }
 
 public final class com/skydoves/landscapist/core/cache/CachedImage {
-	public fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;J)V
+	public fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
 	public final fun component2 ()Lcom/skydoves/landscapist/core/model/DataSource;
 	public final fun component3 ()J
-	public final fun copy (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;J)Lcom/skydoves/landscapist/core/cache/CachedImage;
-	public static synthetic fun copy$default (Lcom/skydoves/landscapist/core/cache/CachedImage;Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JILjava/lang/Object;)Lcom/skydoves/landscapist/core/cache/CachedImage;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;)Lcom/skydoves/landscapist/core/cache/CachedImage;
+	public static synthetic fun copy$default (Lcom/skydoves/landscapist/core/cache/CachedImage;Ljava/lang/Object;Lcom/skydoves/landscapist/core/model/DataSource;JIILjava/lang/String;ILjava/lang/Object;)Lcom/skydoves/landscapist/core/cache/CachedImage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getData ()Ljava/lang/Object;
 	public final fun getDataSource ()Lcom/skydoves/landscapist/core/model/DataSource;
+	public final fun getDiskCachePath ()Ljava/lang/String;
+	public final fun getOriginalHeight ()I
+	public final fun getOriginalWidth ()I
 	public final fun getSizeBytes ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/Landscapist.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/Landscapist.kt
@@ -144,6 +144,9 @@ public class Landscapist private constructor(
           ImageResult.Success(
             data = cached.data,
             dataSource = DataSource.MEMORY,
+            originalWidth = cached.originalWidth,
+            originalHeight = cached.originalHeight,
+            diskCachePath = cached.diskCachePath,
           ),
         )
         return@flow
@@ -190,6 +193,9 @@ public class Landscapist private constructor(
                 data = bitmap,
                 dataSource = DataSource.DISK,
                 sizeBytes = estimateBitmapSize(decodeResult.width, decodeResult.height),
+                originalWidth = decodeResult.width,
+                originalHeight = decodeResult.height,
+                diskCachePath = diskPath,
               )
             }
 
@@ -266,6 +272,9 @@ public class Landscapist private constructor(
                 data = bitmap,
                 dataSource = DataSource.NETWORK,
                 sizeBytes = estimateBitmapSize(decodeResult.width, decodeResult.height),
+                originalWidth = decodeResult.width,
+                originalHeight = decodeResult.height,
+                diskCachePath = diskPath,
               )
             }
 
@@ -300,6 +309,8 @@ public class Landscapist private constructor(
             data = image,
             dataSource = fetchResult.dataSource,
             sizeBytes = estimateBitmapSize(fetchResult.width, fetchResult.height),
+            originalWidth = fetchResult.width,
+            originalHeight = fetchResult.height,
           )
         }
 
@@ -376,6 +387,9 @@ public class Landscapist private constructor(
               data = bitmap,
               dataSource = dataSource,
               sizeBytes = estimateBitmapSize(result.width, result.height),
+              originalWidth = result.width,
+              originalHeight = result.height,
+              diskCachePath = diskPath,
             )
           }
 

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/cache/MemoryCache.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/cache/MemoryCache.kt
@@ -86,9 +86,16 @@ public interface MemoryCache {
  * @property data The image data (platform-specific bitmap type).
  * @property dataSource The source from which the image was originally loaded.
  * @property sizeBytes The size of the image in bytes.
+ * @property originalWidth The original width of the image before any transformations.
+ * @property originalHeight The original height of the image before any transformations.
+ * @property diskCachePath The disk cache file path, if available. Used by sub-sampling plugins
+ *   to create a region decoder from the cached file on subsequent memory cache hits.
  */
 public data class CachedImage(
   val data: Any,
   val dataSource: DataSource,
   val sizeBytes: Long,
+  val originalWidth: Int = 0,
+  val originalHeight: Int = 0,
+  val diskCachePath: String? = null,
 )


### PR DESCRIPTION
Track the original width/height sizes for the cached image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cached images now include additional metadata: original width, original height, and disk cache path information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->