### PR TITLE
Fix ImageBitmap models with LandscapistImage

### DIFF
--- a/landscapist-image/src/androidMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.android.kt
+++ b/landscapist-image/src/androidMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.android.kt
@@ -19,13 +19,14 @@ import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
 import com.skydoves.landscapist.rememberDrawablePainter
 
 /**
- * Creates and remembers a [Painter] from Android Bitmap or Drawable data.
+ * Creates and remembers a [Painter] from Android Bitmap, Drawable, or ImageBitmap data.
  * Supports animated drawables (GIF, APNG, animated WebP) on API 28+.
  */
 @Composable
@@ -33,6 +34,7 @@ public actual fun rememberLandscapistPainter(data: Any?): Painter {
   return when (data) {
     is Bitmap -> remember(data) { BitmapPainter(data.asImageBitmap()) }
     is Drawable -> rememberDrawablePainter(data)
+    is ImageBitmap -> remember(data) { BitmapPainter(data) }
     else -> EmptyPainter
   }
 }

--- a/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.skia.kt
+++ b/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.skia.kt
@@ -17,6 +17,7 @@ package com.skydoves.landscapist.image
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asComposeImageBitmap
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.Painter
@@ -26,7 +27,7 @@ import org.jetbrains.skia.Bitmap
 import org.jetbrains.skia.Image
 
 /**
- * Creates and remembers a [Painter] from Skia Bitmap or RawImageData.
+ * Creates and remembers a [Painter] from Skia Bitmap, RawImageData, or ImageBitmap.
  * Used by Apple (iOS/macOS) and Wasm platforms.
  */
 @Composable
@@ -42,6 +43,7 @@ public actual fun rememberLandscapistPainter(data: Any?): Painter {
           EmptyPainter
         }
       }
+      is ImageBitmap -> BitmapPainter(data)
       else -> EmptyPainter
     }
   }


### PR DESCRIPTION
Currently, passing an ImageBitmap into LandscapistImage results in no image being displayed. This is because ImageBitmap passes the `isBitmapType` check and uses the `LandscapistImageFastPath` composable. The fast path composable creates a painter using `rememberLandscapistPainter` from this data. However, `rememberLandscapistPainter` does not actually handle the ImageBitmap type and simply returns `EmptyPainter`. This PR just adds proper handling for this path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for ImageBitmap format on Android and Skia platforms, enabling improved flexibility in image handling across the painter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->