### PR TITLE
Bump Kotlin to 2.3.10

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-kotlin = "2.3.0"
+kotlin = "2.3.10"
 dokka = "2.1.0"
 jvmTarget = "17"
-nexusPlugin = "0.35.0"
+nexusPlugin = "0.36.0"
 kotlinxCoroutines = "1.10.2"
 kotlinBinaryCompatibility = "0.18.1"
 androidGradlePlugin = "9.0.0"
@@ -28,7 +28,7 @@ ktor = "3.4.0"
 okio = "3.16.4"
 atomicfu = "0.27.0"
 palette = "3.1.0"
-ksp = "2.3.4"
+ksp = "2.3.5"
 spotless = "6.21.0"
 
 [libraries]


### PR DESCRIPTION
Bump Kotlin to 2.3.10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: Kotlin to version 2.3.10, Nexus Plugin to version 0.36.0, and KSP to version 2.3.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->