### PR TITLE
Migrate to JetBrains compose deps and remove javaDocReleaseGeneration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Publish to MavenCentral
         run: |
-          ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache -x javaDocReleaseGeneration -x :fresco:javaDocReleaseGeneration
+          ./gradlew publishAllPublicationsToMavenCentral --no-configuration-cache
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}

--- a/coil3/build.gradle.kts
+++ b/coil3/build.gradle.kts
@@ -53,9 +53,9 @@ kotlin {
         api(libs.coil3.network.core)
         api(libs.kotlinx.serialization.json)
 
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
         implementation(compose.components.resources)
       }
     }
@@ -96,9 +96,11 @@ kotlin {
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,6 +87,9 @@ ktor-engine-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 okio = { group = "com.squareup.okio", name = "okio", version.ref = "okio" }
 atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+jetbrains-compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "jetbrains-compose" }
+jetbrains-compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "jetbrains-compose" }
+jetbrains-compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "jetbrains-compose" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }

--- a/landscapist-animation/build.gradle.kts
+++ b/landscapist-animation/build.gradle.kts
@@ -48,9 +48,9 @@ kotlin {
       dependencies {
         api(project(":landscapist"))
 
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
       }
     }
 
@@ -63,9 +63,11 @@ kotlin {
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/landscapist-image/build.gradle.kts
+++ b/landscapist-image/build.gradle.kts
@@ -55,9 +55,9 @@ kotlin {
         api(project(":landscapist-core"))
 
         // Compose
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
         implementation(compose.components.resources)
       }
     }
@@ -71,9 +71,11 @@ kotlin {
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/landscapist-palette/build.gradle.kts
+++ b/landscapist-palette/build.gradle.kts
@@ -49,18 +49,20 @@ kotlin {
         api(project(":landscapist"))
         api(libs.palette)
 
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
       }
     }
   }
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/landscapist-placeholder/build.gradle.kts
+++ b/landscapist-placeholder/build.gradle.kts
@@ -48,9 +48,9 @@ kotlin {
       dependencies {
         api(project(":landscapist"))
 
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
       }
     }
 
@@ -63,9 +63,11 @@ kotlin {
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/landscapist-zoomable/build.gradle.kts
+++ b/landscapist-zoomable/build.gradle.kts
@@ -48,9 +48,9 @@ kotlin {
       dependencies {
         api(project(":landscapist"))
 
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
       }
     }
 
@@ -63,9 +63,11 @@ kotlin {
 
   targets.configureEach {
     compilations.configureEach {
-      compilerOptions.configure {
-        // https://youtrack.jetbrains.com/issue/KT-61573
-        freeCompilerArgs.add("-Xexpect-actual-classes")
+      compileTaskProvider.configure {
+        compilerOptions {
+          // https://youtrack.jetbrains.com/issue/KT-61573
+          freeCompilerArgs.add("-Xexpect-actual-classes")
+        }
       }
     }
   }

--- a/landscapist/build.gradle.kts
+++ b/landscapist/build.gradle.kts
@@ -47,9 +47,9 @@ kotlin {
     }
     commonMain {
       dependencies {
-        implementation(compose.ui)
-        implementation(compose.runtime)
-        implementation(compose.foundation)
+        implementation(libs.jetbrains.compose.ui)
+        implementation(libs.jetbrains.compose.runtime)
+        implementation(libs.jetbrains.compose.foundation)
         implementation(libs.kotlinx.coroutines.core)
       }
     }


### PR DESCRIPTION
Migrate to JetBrains compose deps and remove javaDocReleaseGeneration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to use centralized dependency catalog for Compose libraries across multiple modules.
  * Restructured Gradle compiler configuration for improved organization.
  * Modified publishing workflow to enable JavaDoc generation during release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->