### PR TITLE
Drop intel based iOS version following the androidx runtime annotation

### DIFF
--- a/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/ComposeMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/ComposeMultiplatform.kt
@@ -50,11 +50,9 @@ internal fun Project.configureComposeMultiplatform(
       binaries.library()
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 
-    macosX64()
     macosArm64()
 
     @Suppress("OPT_IN_USAGE")
@@ -69,12 +67,10 @@ internal fun Project.configureComposeMultiplatform(
           group("darwin") {
             group("apple") {
               group("ios") {
-                withIosX64()
                 withIosArm64()
                 withIosSimulatorArm64()
               }
               group("macos") {
-                withMacosX64()
                 withMacosArm64()
               }
             }

--- a/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/ComposeMultiplatformWasm.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/ComposeMultiplatformWasm.kt
@@ -50,11 +50,9 @@ internal fun Project.configureComposeMultiplatformWasm(
       binaries.library()
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 
-    macosX64()
     macosArm64()
 
     @Suppress("OPT_IN_USAGE")
@@ -69,12 +67,10 @@ internal fun Project.configureComposeMultiplatformWasm(
           group("darwin") {
             group("apple") {
               group("ios") {
-                withIosX64()
                 withIosArm64()
                 withIosSimulatorArm64()
               }
               group("macos") {
-                withMacosX64()
                 withMacosArm64()
               }
             }

--- a/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/KmpLibrary.kt
+++ b/build-logic/convention/src/main/kotlin/com/skydoves/landscapist/KmpLibrary.kt
@@ -48,11 +48,9 @@ internal fun Project.configureKmpLibrary(
       binaries.library()
     }
 
-    iosX64()
     iosArm64()
     iosSimulatorArm64()
 
-    macosX64()
     macosArm64()
 
     @Suppress("OPT_IN_USAGE")
@@ -67,12 +65,10 @@ internal fun Project.configureKmpLibrary(
           group("darwin") {
             group("apple") {
               group("ios") {
-                withIosX64()
                 withIosArm64()
                 withIosSimulatorArm64()
               }
               group("macos") {
-                withMacosX64()
                 withMacosArm64()
               }
             }


### PR DESCRIPTION
Drop intel based iOS version following the androidx runtime annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed iOS x64 (Intel-based simulator) target support from the build configuration, now supporting only iOS ARM64 and iOS ARM64 Simulator variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->