### PR TITLE
Bump Kotlin to 2.4.0

### DIFF
--- a/buildSrc/src/main/kotlin/com/github/skydoves/landscapist/Configuration.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/landscapist/Configuration.kt
@@ -17,7 +17,7 @@
 package com.github.skydoves.landscapist
 
 object Configuration {
-  const val compileSdk = 36
+  const val compileSdk = 37
   const val targetSdk = 36
   const val minSdk = 21
   const val minSdk24 = 24

--- a/coil/api/coil.api
+++ b/coil/api/coil.api
@@ -59,8 +59,8 @@ public final class com/skydoves/landscapist/coil/CoilImageStateKt {
 public final class com/skydoves/landscapist/coil/ComposableSingletons$CoilImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/coil/ComposableSingletons$CoilImageKt;
 	public fun <init> ()V
-	public final fun getLambda$-267398626$coil_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-822817582$coil_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-267398626$LandscapistDemo_coil_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-822817582$LandscapistDemo_coil_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/coil/LocalCoilProviderKt {

--- a/coil/stability/coil-debug.stability
+++ b/coil/stability/coil-debug.stability
@@ -16,7 +16,7 @@ public fun com.skydoves.landscapist.coil.CoilImage(imageModel: kotlin.Function0<
     - requestListener: STABLE (function type)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -32,7 +32,7 @@ public fun com.skydoves.landscapist.coil.CoilImage(imageRequest: kotlin.Function
     - component: STABLE (marked @Stable or @Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -70,16 +70,16 @@ public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: co
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: android.content.Context, imageLoader: coil.ImageLoader, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
   restartable: true
   params:
-    - context: RUNTIME (requires runtime check)
-    - imageLoader: RUNTIME (requires runtime check)
-    - imageModel: UNSTABLE (has mutable properties or unstable members)
+    - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageLoader: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - dataSource: STABLE (class with no mutable properties)
 
 @Composable

--- a/coil/stability/coil-release.stability
+++ b/coil/stability/coil-release.stability
@@ -16,7 +16,7 @@ public fun com.skydoves.landscapist.coil.CoilImage(imageModel: kotlin.Function0<
     - requestListener: STABLE (function type)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -32,7 +32,7 @@ public fun com.skydoves.landscapist.coil.CoilImage(imageRequest: kotlin.Function
     - component: STABLE (marked @Stable or @Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -70,16 +70,16 @@ public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: co
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: android.content.Context, imageLoader: coil.ImageLoader, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
   restartable: true
   params:
-    - context: RUNTIME (requires runtime check)
-    - imageLoader: RUNTIME (requires runtime check)
-    - imageModel: UNSTABLE (has mutable properties or unstable members)
+    - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageLoader: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - dataSource: STABLE (class with no mutable properties)
 
 @Composable

--- a/coil3/api/android/coil3.api
+++ b/coil3/api/android/coil3.api
@@ -59,8 +59,8 @@ public final class com/skydoves/landscapist/coil3/CoilImageStateKt {
 public final class com/skydoves/landscapist/coil3/ComposableSingletons$CoilImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/coil3/ComposableSingletons$CoilImageKt;
 	public fun <init> ()V
-	public final fun getLambda$1026879375$coil3_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$988760923$coil3_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1026879375$LandscapistDemo_coil3_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$988760923$LandscapistDemo_coil3_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/coil3/LocalCoilProviderKt {

--- a/coil3/api/desktop/coil3.api
+++ b/coil3/api/desktop/coil3.api
@@ -59,8 +59,8 @@ public final class com/skydoves/landscapist/coil3/CoilImageStateKt {
 public final class com/skydoves/landscapist/coil3/ComposableSingletons$CoilImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/coil3/ComposableSingletons$CoilImageKt;
 	public fun <init> ()V
-	public final fun getLambda$1026879375$coil3 ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$988760923$coil3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1026879375$LandscapistDemo_coil3 ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$988760923$LandscapistDemo_coil3 ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/coil3/LocalCoilProviderKt {

--- a/fresco-websupport/stability/fresco-websupport-debug.stability
+++ b/fresco-websupport/stability/fresco-websupport-debug.stability
@@ -16,5 +16,5 @@ public fun com.skydoves.landscapist.fresco.websupport.FrescoWebImage(controllerB
     - contentScale: STABLE (marked @Stable or @Immutable)
     - alpha: STABLE (primitive type)
     - colorFilter: STABLE (marked @Stable or @Immutable)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
 

--- a/fresco-websupport/stability/fresco-websupport-release.stability
+++ b/fresco-websupport/stability/fresco-websupport-release.stability
@@ -16,5 +16,5 @@ public fun com.skydoves.landscapist.fresco.websupport.FrescoWebImage(controllerB
     - contentScale: STABLE (marked @Stable or @Immutable)
     - alpha: STABLE (primitive type)
     - colorFilter: STABLE (marked @Stable or @Immutable)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
 

--- a/fresco/api/fresco.api
+++ b/fresco/api/fresco.api
@@ -1,7 +1,7 @@
 public final class com/skydoves/landscapist/fresco/ComposableSingletons$FrescoImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/fresco/ComposableSingletons$FrescoImageKt;
 	public fun <init> ()V
-	public final fun getLambda$1668044598$fresco_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1668044598$LandscapistDemo_fresco_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/fresco/FrescoImage {

--- a/fresco/stability/fresco-debug.stability
+++ b/fresco/stability/fresco-debug.stability
@@ -15,7 +15,7 @@ public fun com.skydoves.landscapist.fresco.FrescoImage(imageUrl: kotlin.String?,
     - component: STABLE (marked @Stable or @Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -53,7 +53,7 @@ internal fun com.skydoves.landscapist.fresco.rememberCloseableRef(ref: com.faceb
   skippable: false
   restartable: true
   params:
-    - ref: RUNTIME (requires runtime check)
+    - ref: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState: com.skydoves.landscapist.fresco.FrescoImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.fresco.FrescoImageState>
@@ -61,7 +61,7 @@ public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.toFrescoImageState(): com.skydoves.landscapist.fresco.FrescoImageState

--- a/fresco/stability/fresco-release.stability
+++ b/fresco/stability/fresco-release.stability
@@ -15,7 +15,7 @@ public fun com.skydoves.landscapist.fresco.FrescoImage(imageUrl: kotlin.String?,
     - component: STABLE (marked @Stable or @Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -53,7 +53,7 @@ internal fun com.skydoves.landscapist.fresco.rememberCloseableRef(ref: com.faceb
   skippable: false
   restartable: true
   params:
-    - ref: RUNTIME (requires runtime check)
+    - ref: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState: com.skydoves.landscapist.fresco.FrescoImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.fresco.FrescoImageState>
@@ -61,7 +61,7 @@ public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.toFrescoImageState(): com.skydoves.landscapist.fresco.FrescoImageState

--- a/glide/api/glide.api
+++ b/glide/api/glide.api
@@ -1,7 +1,7 @@
 public final class com/skydoves/landscapist/glide/ComposableSingletons$GlideImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/glide/ComposableSingletons$GlideImageKt;
 	public fun <init> ()V
-	public final fun getLambda$1443599613$glide_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1443599613$LandscapistDemo_glide_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/glide/GlideImage {

--- a/glide/stability/glide-debug.stability
+++ b/glide/stability/glide-debug.stability
@@ -19,7 +19,7 @@ public fun com.skydoves.landscapist.glide.GlideImage(imageModel: kotlin.Function
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - clearTarget: STABLE (primitive type)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -72,15 +72,15 @@ public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: 
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: android.content.Context, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
   restartable: true
   params:
-    - context: RUNTIME (requires runtime check)
-    - imageModel: UNSTABLE (has mutable properties or unstable members)
+    - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - dataSource: STABLE (class with no mutable properties)
 
 @Composable

--- a/glide/stability/glide-release.stability
+++ b/glide/stability/glide-release.stability
@@ -19,7 +19,7 @@ public fun com.skydoves.landscapist.glide.GlideImage(imageModel: kotlin.Function
     - imageOptions: STABLE (marked @Stable or @Immutable)
     - clearTarget: STABLE (primitive type)
     - onImageStateChanged: STABLE (function type)
-    - previewPlaceholder: RUNTIME (requires runtime check)
+    - previewPlaceholder: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - loading: STABLE (composable function type)
     - success: STABLE (composable function type)
     - failure: STABLE (composable function type)
@@ -72,15 +72,15 @@ public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: 
   restartable: true
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
-    - key: UNSTABLE (has mutable properties or unstable members)
+    - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: android.content.Context, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
   restartable: true
   params:
-    - context: RUNTIME (requires runtime check)
-    - imageModel: UNSTABLE (has mutable properties or unstable members)
+    - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - dataSource: STABLE (class with no mutable properties)
 
 @Composable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 dokka = "2.2.0"
 jvmTarget = "17"
 nexusPlugin = "0.36.0"
@@ -28,7 +28,7 @@ ktor = "3.5.0"
 okio = "3.17.0"
 atomicfu = "0.27.0"
 palette = "3.1.0"
-ksp = "2.3.6"
+ksp = "2.3.9"
 spotless = "6.21.0"
 
 [libraries]

--- a/landscapist-image-gallery/api/android/landscapist-image-gallery.api
+++ b/landscapist-image-gallery/api/android/landscapist-image-gallery.api
@@ -1,13 +1,13 @@
 public final class com/skydoves/landscapist/gallery/ComposableSingletons$ImageGalleryKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/gallery/ComposableSingletons$ImageGalleryKt;
 	public fun <init> ()V
-	public final fun getLambda$-2002893656$landscapist_image_gallery_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-2002893656$LandscapistDemo_landscapist_image_gallery_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/gallery/ComposableSingletons$ImageViewerKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/gallery/ComposableSingletons$ImageViewerKt;
 	public fun <init> ()V
-	public final fun getLambda$1733709853$landscapist_image_gallery_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1733709853$LandscapistDemo_landscapist_image_gallery_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/gallery/ImageGalleryDefaults {

--- a/landscapist-image-gallery/api/desktop/landscapist-image-gallery.api
+++ b/landscapist-image-gallery/api/desktop/landscapist-image-gallery.api
@@ -1,13 +1,13 @@
 public final class com/skydoves/landscapist/gallery/ComposableSingletons$ImageGalleryKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/gallery/ComposableSingletons$ImageGalleryKt;
 	public fun <init> ()V
-	public final fun getLambda$-2002893656$landscapist_image_gallery ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-2002893656$LandscapistDemo_landscapist_image_gallery ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/gallery/ComposableSingletons$ImageViewerKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/gallery/ComposableSingletons$ImageViewerKt;
 	public fun <init> ()V
-	public final fun getLambda$1733709853$landscapist_image_gallery ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1733709853$LandscapistDemo_landscapist_image_gallery ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/gallery/ImageGalleryDefaults {

--- a/landscapist-image/api/android/landscapist-image.api
+++ b/landscapist-image/api/android/landscapist-image.api
@@ -1,8 +1,8 @@
 public final class com/skydoves/landscapist/image/ComposableSingletons$LandscapistImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/image/ComposableSingletons$LandscapistImageKt;
 	public fun <init> ()V
-	public final fun getLambda$-1726880433$landscapist_image_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-30246008$landscapist_image_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1726880433$LandscapistDemo_landscapist_image_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-30246008$LandscapistDemo_landscapist_image_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/image/ImageBitmapConverter_androidKt {

--- a/landscapist-image/api/desktop/landscapist-image.api
+++ b/landscapist-image/api/desktop/landscapist-image.api
@@ -1,8 +1,8 @@
 public final class com/skydoves/landscapist/image/ComposableSingletons$LandscapistImageKt {
 	public static final field INSTANCE Lcom/skydoves/landscapist/image/ComposableSingletons$LandscapistImageKt;
 	public fun <init> ()V
-	public final fun getLambda$-1726880433$landscapist_image ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-30246008$landscapist_image ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1726880433$LandscapistDemo_landscapist_image ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-30246008$LandscapistDemo_landscapist_image ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class com/skydoves/landscapist/image/ImageBitmapConverter_skiaKt {

--- a/landscapist-transformation/stability/landscapist-transformation-debug.stability
+++ b/landscapist-transformation/stability/landscapist-transformation-debug.stability
@@ -9,14 +9,14 @@ public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin
   skippable: false
   restartable: true
   params:
-    - imageBitmap: RUNTIME (requires runtime check)
-    - painter: RUNTIME (requires runtime check)
+    - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.transformation.blur.rememberBlurPainter(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, radius: kotlin.Int): androidx.compose.ui.graphics.painter.Painter
   skippable: false
   restartable: true
   params:
-    - imageBitmap: RUNTIME (requires runtime check)
+    - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - radius: STABLE (primitive type)
 

--- a/landscapist-transformation/stability/landscapist-transformation-release.stability
+++ b/landscapist-transformation/stability/landscapist-transformation-release.stability
@@ -9,14 +9,14 @@ public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin
   skippable: false
   restartable: true
   params:
-    - imageBitmap: RUNTIME (requires runtime check)
-    - painter: RUNTIME (requires runtime check)
+    - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
+    - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 internal fun com.skydoves.landscapist.transformation.blur.rememberBlurPainter(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, radius: kotlin.Int): androidx.compose.ui.graphics.painter.Painter
   skippable: false
   restartable: true
   params:
-    - imageBitmap: RUNTIME (requires runtime check)
+    - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - radius: STABLE (primitive type)
 


### PR DESCRIPTION
Bump Kotlin to 2.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Android compilation SDK to version 37
  * Updated Kotlin compiler to version 2.4.0
  * Updated Kotlin Symbol Processing plugin to version 2.3.9 for improved code generation performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->