### PR TITLE
Add onTap callback to ZoomablePlugin (#863)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,9 @@ androidxUiAutomator = "2.3.0"
 composeStabilityAnalyzer = "0.10.0"
 kotlinxSerializationJson = "1.11.0"
 jetbrains-compose = "1.11.1"
+# Native runtime for desktop Compose UI tests. Must match the skiko version that
+# jetbrains-compose pulls transitively (org.jetbrains.skiko:skiko).
+skiko = "0.144.6"
 glide = "5.0.7"
 fresco = "3.7.0"
 coil = "2.7.0"
@@ -90,6 +93,8 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 jetbrains-compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "jetbrains-compose" }
 compose-runtime-annotation = { group = "androidx.compose.runtime", name = "runtime-annotation", version = "1.11.3" }
 jetbrains-compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "jetbrains-compose" }
+jetbrains-compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test", version.ref = "jetbrains-compose" }
+jetbrains-compose-ui-test-junit4 = { group = "org.jetbrains.compose.ui", name = "ui-test-junit4", version.ref = "jetbrains-compose" }
 jetbrains-compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "jetbrains-compose" }
 jetbrains-compose-animation = { group = "org.jetbrains.compose.animation", name = "animation", version.ref = "jetbrains-compose" }
 

--- a/landscapist-zoomable/build.gradle.kts
+++ b/landscapist-zoomable/build.gradle.kts
@@ -17,6 +17,19 @@ import com.github.skydoves.landscapist.Configuration
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
+/** Resolves the skiko native runtime classifier (e.g. "macos-arm64") for the running host. */
+fun skikoHostTarget(): String {
+  val os = System.getProperty("os.name").lowercase()
+  val arch = System.getProperty("os.arch").lowercase()
+  val osPart = when {
+    os.contains("mac") || os.contains("darwin") -> "macos"
+    os.contains("windows") -> "windows"
+    else -> "linux"
+  }
+  val archPart = if (arch.contains("aarch64") || arch.contains("arm64")) "arm64" else "x64"
+  return "$osPart-$archPart"
+}
+
 plugins {
   id("landscapist.library.compose.multiplatformWasm")
   id("landscapist.spotless")
@@ -59,6 +72,18 @@ kotlin {
         implementation(libs.androidx.core.ktx)
       }
     }
+
+    val desktopTest by getting {
+      dependencies {
+        implementation(kotlin("test"))
+        implementation(libs.jetbrains.compose.ui.test.junit4)
+        implementation(libs.jetbrains.compose.foundation)
+        // Skiko native runtime for the host OS, required to render off-screen during the
+        // desktop runComposeUiTest runs. The classifier is resolved from the running host so the
+        // tests also run on CI (e.g. linux-x64).
+        runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-${skikoHostTarget()}:${libs.versions.skiko.get()}")
+      }
+    }
   }
 
   targets.configureEach {
@@ -92,8 +117,11 @@ baselineProfile {
 tasks.withType<KotlinJvmCompile>().configureEach {
   compilerOptions {
     jvmTarget.set(JvmTarget.JVM_17)
+    // Only apply explicit API mode to main sources, not tests
+    if (!name.contains("Test")) {
+      freeCompilerArgs.add("-Xexplicit-api=strict")
+    }
     freeCompilerArgs.addAll(
-      "-Xexplicit-api=strict",
       "-opt-in=kotlin.RequiresOptIn",
       "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi",
       "-opt-in=com.skydoves.landscapist.InternalLandscapistApi",

--- a/landscapist-zoomable/src/androidMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.android.kt
+++ b/landscapist-zoomable/src/androidMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.android.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import com.skydoves.landscapist.LocalImageSourceFile
@@ -51,6 +52,7 @@ internal actual fun ZoomableContent(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)?,
   content: @Composable () -> Unit,
 ) {
   // First try to get decoder from LocalImageRegionDecoder (explicitly provided)
@@ -109,6 +111,7 @@ internal actual fun ZoomableContent(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
       content = content,
     )
   } else {
@@ -117,6 +120,7 @@ internal actual fun ZoomableContent(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
       content = content,
     )
   }
@@ -131,6 +135,7 @@ private fun SubSamplingImageWithPlaceholder(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)?,
   content: @Composable () -> Unit,
 ) {
   val isBaseLoaded = subSamplingState.isBaseLoaded
@@ -142,6 +147,7 @@ private fun SubSamplingImageWithPlaceholder(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
     )
 
     // Show original content as placeholder on top until base tile is loaded
@@ -164,6 +170,7 @@ internal fun StandardZoomableContent(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
   val transformation = zoomableState.transformation
@@ -179,6 +186,7 @@ internal fun StandardZoomableContent(
           Modifier.zoomGestures(
             state = zoomableState,
             config = config,
+            onTap = onTap,
           )
         } else {
           Modifier

--- a/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/ZoomablePlugin.kt
+++ b/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/ZoomablePlugin.kt
@@ -17,6 +17,7 @@ package com.skydoves.landscapist.zoomable
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.ui.geometry.Offset
 import com.skydoves.landscapist.plugins.ImagePlugin
 import com.skydoves.landscapist.zoomable.internal.ZoomableContent
 
@@ -38,18 +39,18 @@ import com.skydoves.landscapist.zoomable.internal.ZoomableContent
  *
  * **With custom configuration:**
  * ```kotlin
- * val zoomableState = rememberZoomableState()
+ * // Configuration is supplied through the state.
+ * val zoomableState = rememberZoomableState(
+ *   config = ZoomableConfig(
+ *     maxZoom = 8f,
+ *     doubleTapZoom = 3f,
+ *   ),
+ * )
  *
  * GlideImage(
  *   imageModel = { imageUrl },
  *   component = rememberImageComponent {
- *     +ZoomablePlugin(
- *       state = zoomableState,
- *       config = ZoomableConfig(
- *         maxZoom = 8f,
- *         doubleTapZoom = 3f,
- *       ),
- *     )
+ *     +ZoomablePlugin(state = zoomableState)
  *   },
  * )
  *
@@ -57,6 +58,18 @@ import com.skydoves.landscapist.zoomable.internal.ZoomableContent
  * Button(onClick = { scope.launch { zoomableState.resetZoom() } }) {
  *   Text("Reset")
  * }
+ * ```
+ *
+ * **Handling taps:** because the zoom gesture detector consumes the pointer down, a parent
+ * `Modifier.clickable` will not receive taps while zoom gestures are enabled. Use [onTap] to react
+ * to single taps instead:
+ * ```kotlin
+ * GlideImage(
+ *   imageModel = { imageUrl },
+ *   component = rememberImageComponent {
+ *     +ZoomablePlugin(onTap = { position -> openFullScreen() })
+ *   },
+ * )
  * ```
  *
  * **Reset zoom when image changes:**
@@ -75,12 +88,16 @@ import com.skydoves.landscapist.zoomable.internal.ZoomableContent
  *   If null, a new state will be created internally.
  * @property enabled Whether zoom gestures are enabled.
  * @property onTransformChanged Callback invoked when the transformation changes.
+ * @property onTap Callback invoked with the tap position on a single tap. Use this to handle taps
+ *   on the image, since the zoom gesture detector consumes the pointer down and a parent
+ *   `Modifier.clickable` therefore does not receive the tap while zoom gestures are enabled.
  */
 @Immutable
 public data class ZoomablePlugin(
   public val state: ZoomableState? = null,
   public val enabled: Boolean = true,
   public val onTransformChanged: ((ContentTransformation) -> Unit)? = null,
+  public val onTap: ((Offset) -> Unit)? = null,
 ) : ImagePlugin.ComposablePlugin {
 
   /**
@@ -104,6 +121,7 @@ public data class ZoomablePlugin(
       zoomableState = zoomableState,
       config = zoomableState.config,
       enabled = enabled,
+      onTap = onTap,
       content = content,
     )
   }

--- a/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomGestureDetector.kt
+++ b/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomGestureDetector.kt
@@ -37,28 +37,38 @@ import kotlinx.coroutines.launch
  *
  * @param state The [ZoomableState] to update based on gestures.
  * @param config The [ZoomableConfig] for gesture behavior configuration.
+ * @param onTap Optional callback invoked with the tap position on a single tap. Provide this to
+ *   receive tap events, since the tap detector consumes the pointer down and a parent
+ *   `Modifier.clickable` therefore does not fire while tap handling is active.
  */
 internal fun Modifier.zoomGestures(
   state: ZoomableState,
   config: ZoomableConfig,
+  onTap: ((Offset) -> Unit)? = null,
 ): Modifier = composed {
   val scope = rememberCoroutineScope()
 
   this
-    // Handle double-tap to zoom FIRST
+    // Handle double-tap to zoom and single-tap callbacks FIRST.
+    // Install this detector only when it has something to do, so that with both double-tap zoom and
+    // onTap disabled a single tap stays unconsumed and can reach a parent gesture handler.
     .then(
-      if (config.enableDoubleTapZoom) {
-        Modifier.pointerInput(state, config) {
+      if (config.enableDoubleTapZoom || onTap != null) {
+        Modifier.pointerInput(state, config, onTap) {
           detectTapGestures(
-            onTap = { /* Allow single tap to pass through */ },
-            onDoubleTap = { offset ->
-              scope.launch {
-                if (state.isZoomed) {
-                  state.resetZoom()
-                } else {
-                  state.zoomTo(config.doubleTapZoom, offset)
+            onTap = { offset -> onTap?.invoke(offset) },
+            onDoubleTap = if (config.enableDoubleTapZoom) {
+              { offset ->
+                scope.launch {
+                  if (state.isZoomed) {
+                    state.resetZoom()
+                  } else {
+                    state.zoomTo(config.doubleTapZoom, offset)
+                  }
                 }
               }
+            } else {
+              null
             },
           )
         }

--- a/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.kt
+++ b/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.kt
@@ -16,6 +16,7 @@
 package com.skydoves.landscapist.zoomable.internal
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.geometry.Offset
 import com.skydoves.landscapist.zoomable.ZoomableConfig
 import com.skydoves.landscapist.zoomable.ZoomableState
 
@@ -30,6 +31,7 @@ import com.skydoves.landscapist.zoomable.ZoomableState
  * @param zoomableState The [ZoomableState] managing zoom transformations.
  * @param config The [ZoomableConfig] for zoom behavior.
  * @param enabled Whether zoom gestures are enabled.
+ * @param onTap Optional callback invoked with the tap position on a single tap.
  * @param content The image content to display.
  */
 @Composable
@@ -37,5 +39,6 @@ internal expect fun ZoomableContent(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)?,
   content: @Composable () -> Unit,
 )

--- a/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/subsampling/SubSamplingImage.kt
+++ b/landscapist-zoomable/src/commonMain/kotlin/com/skydoves/landscapist/zoomable/subsampling/SubSamplingImage.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.debounce
  * @param enabled Whether zoom gestures are enabled.
  * @param modifier The modifier to apply to the composable.
  * @param contentDescription The content description for accessibility.
+ * @param onTap Optional callback invoked with the tap position on a single tap.
  */
 @Composable
 public fun SubSamplingImage(
@@ -62,6 +63,7 @@ public fun SubSamplingImage(
   enabled: Boolean = true,
   modifier: Modifier = Modifier,
   contentDescription: String? = null,
+  onTap: ((Offset) -> Unit)? = null,
 ) {
   var viewportSize by remember { mutableStateOf(IntSize.Zero) }
   var currentFitScale by remember { mutableFloatStateOf(1f) }
@@ -124,6 +126,7 @@ public fun SubSamplingImage(
           Modifier.zoomGestures(
             state = zoomableState,
             config = config,
+            onTap = onTap,
           )
         } else {
           Modifier

--- a/landscapist-zoomable/src/desktopTest/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomGesturesTest.kt
+++ b/landscapist-zoomable/src/desktopTest/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomGesturesTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.zoomable.internal
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.doubleClick
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.zoomable.ZoomableConfig
+import com.skydoves.landscapist.zoomable.ZoomableState
+import com.skydoves.landscapist.zoomable.rememberZoomableState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Behavior tests for [zoomGestures], covering the tap-callback fix for
+ * https://github.com/skydoves/landscapist/issues/863 while guarding the existing gestures.
+ */
+@OptIn(ExperimentalTestApi::class)
+class ZoomGesturesTest {
+
+  /** Regression: with the default config a double-tap still zooms the content in. */
+  @Test
+  fun doubleTap_zoomsIn_withDefaultConfig() = runComposeUiTest {
+    lateinit var state: ZoomableState
+    setContent {
+      state = rememberZoomableState()
+      Box(
+        modifier = Modifier
+          .size(200.dp)
+          .testTag(TARGET)
+          .zoomGestures(state = state, config = ZoomableConfig()),
+      )
+    }
+
+    assertFalse(state.isZoomed)
+    onNodeWithTag(TARGET).performTouchInput { doubleClick() }
+    waitUntil(timeoutMillis = TIMEOUT) { state.isZoomed }
+
+    assertTrue(state.isZoomed)
+  }
+
+  /** Regression: a second double-tap while zoomed resets the zoom. */
+  @Test
+  fun doubleTap_whenZoomed_resetsZoom() = runComposeUiTest {
+    lateinit var state: ZoomableState
+    setContent {
+      state = rememberZoomableState()
+      Box(
+        modifier = Modifier
+          .size(200.dp)
+          .testTag(TARGET)
+          .zoomGestures(state = state, config = ZoomableConfig()),
+      )
+    }
+
+    onNodeWithTag(TARGET).performTouchInput { doubleClick() }
+    waitUntil(timeoutMillis = TIMEOUT) { state.isZoomed }
+
+    onNodeWithTag(TARGET).performTouchInput { doubleClick() }
+    waitUntil(timeoutMillis = TIMEOUT) { !state.isZoomed }
+
+    assertFalse(state.isZoomed)
+  }
+
+  /** New behavior (#863): a single tap invokes the onTap callback. */
+  @Test
+  fun singleTap_invokesOnTapCallback() = runComposeUiTest {
+    var taps = 0
+    setContent {
+      val state = rememberZoomableState()
+      Box(
+        modifier = Modifier
+          .size(200.dp)
+          .testTag(TARGET)
+          .zoomGestures(state = state, config = ZoomableConfig(), onTap = { taps++ }),
+      )
+    }
+
+    onNodeWithTag(TARGET).performTouchInput { click() }
+    waitUntil(timeoutMillis = TIMEOUT) { taps == 1 }
+
+    assertEquals(1, taps)
+  }
+
+  /**
+   * New behavior (#863): onTap is the supported way to react to taps. A parent clickable does not
+   * fire while tap handling is active (the detector consumes the down), so onTap replaces it.
+   */
+  @Test
+  fun singleTap_invokesOnTap_notParentClickable() = runComposeUiTest {
+    var taps = 0
+    var parentClicks = 0
+    setContent {
+      val state = rememberZoomableState()
+      Box(
+        modifier = Modifier
+          .size(200.dp)
+          .testTag(PARENT)
+          .clickable { parentClicks++ },
+      ) {
+        Box(
+          modifier = Modifier
+            .fillMaxSize()
+            .zoomGestures(state = state, config = ZoomableConfig(), onTap = { taps++ }),
+        )
+      }
+    }
+
+    onNodeWithTag(PARENT).performTouchInput { click() }
+    waitUntil(timeoutMillis = TIMEOUT) { taps == 1 }
+
+    assertEquals(1, taps)
+    assertEquals(0, parentClicks)
+  }
+
+  /**
+   * Regression: when both double-tap zoom and onTap are disabled, no tap detector is installed, so
+   * a single tap stays unconsumed and reaches the parent's clickable.
+   */
+  @Test
+  fun singleTap_reachesParent_whenTapHandlingDisabled() = runComposeUiTest {
+    var parentClicks = 0
+    val config = ZoomableConfig(enableDoubleTapZoom = false)
+    setContent {
+      val state = rememberZoomableState(config = config)
+      Box(
+        modifier = Modifier
+          .size(200.dp)
+          .testTag(PARENT)
+          .clickable { parentClicks++ },
+      ) {
+        Box(
+          modifier = Modifier
+            .fillMaxSize()
+            .zoomGestures(state = state, config = config),
+        )
+      }
+    }
+
+    onNodeWithTag(PARENT).performTouchInput { click() }
+    waitUntil(timeoutMillis = TIMEOUT) { parentClicks == 1 }
+
+    assertEquals(1, parentClicks)
+  }
+
+  private companion object {
+    const val TARGET = "target"
+    const val PARENT = "parent"
+    const val TIMEOUT = 5_000L
+  }
+}

--- a/landscapist-zoomable/src/skiaMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.skia.kt
+++ b/landscapist-zoomable/src/skiaMain/kotlin/com/skydoves/landscapist/zoomable/internal/ZoomableContent.skia.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import com.skydoves.landscapist.LocalImageSourceBytes
@@ -46,6 +47,7 @@ internal actual fun ZoomableContent(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)?,
   content: @Composable () -> Unit,
 ) {
   // First try to get decoder from LocalImageRegionDecoder (explicitly provided)
@@ -88,6 +90,7 @@ internal actual fun ZoomableContent(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
       content = content,
     )
   } else {
@@ -96,6 +99,7 @@ internal actual fun ZoomableContent(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
       content = content,
     )
   }
@@ -115,6 +119,7 @@ private fun SubSamplingImageWithPlaceholder(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)?,
   content: @Composable () -> Unit,
 ) {
   Box(modifier = Modifier.clipToBounds()) {
@@ -133,6 +138,7 @@ private fun SubSamplingImageWithPlaceholder(
       zoomableState = zoomableState,
       config = config,
       enabled = enabled,
+      onTap = onTap,
     )
   }
 }
@@ -145,6 +151,7 @@ internal fun StandardZoomableContent(
   zoomableState: ZoomableState,
   config: ZoomableConfig,
   enabled: Boolean,
+  onTap: ((Offset) -> Unit)? = null,
   content: @Composable () -> Unit,
 ) {
   val transformation = zoomableState.transformation
@@ -160,6 +167,7 @@ internal fun StandardZoomableContent(
           Modifier.zoomGestures(
             state = zoomableState,
             config = config,
+            onTap = onTap,
           )
         } else {
           Modifier


### PR DESCRIPTION
## Summary

Fixes #863. When `ZoomablePlugin` is enabled, its double-tap detector consumes the pointer `down` on every tap, so a parent `Modifier.clickable` never fires. This is inherent to `detectTapGestures` (it calls `down.consume()` as soon as a pointer goes down, regardless of whether the gesture becomes a double tap), and the parent's `clickable` requires an *unconsumed* down. A single tap therefore cannot both drive zoom and bubble to a parent.

This PR exposes an `onTap` callback so taps can be handled at the plugin level, which is what the issue asks for ("provide a click callback within the ZoomablePlugin").

## Changes

- Add `ZoomablePlugin.onTap: ((Offset) -> Unit)?` and thread it through `ZoomableContent` (android/skia), `SubSamplingImage`, and `zoomGestures`.
- Install the tap detector when **double-tap zoom OR `onTap`** is set, and make `onDoubleTap` conditional on `enableDoubleTapZoom`. When both are off, no tap detector is installed, so a single tap stays unconsumed and reaches a parent gesture handler (previously the only workaround).
- Fix a stale KDoc example that referenced a nonexistent `ZoomablePlugin(config = ...)` parameter; configuration is supplied via `rememberZoomableState(config = ...)`.

The change is source-compatible: `onTap` defaults to `null`, and with it unset behavior is identical to before.

## Usage

```kotlin
GlideImage(
  imageModel = { imageUrl },
  component = rememberImageComponent {
    +ZoomablePlugin(onTap = { position -> openFullScreen() })
  },
)
```

## Tests

Adds desktop `runComposeUiTest` coverage in `ZoomGesturesTest` (runs on the JVM via `desktopTest`, no emulator):

- `doubleTap_zoomsIn_withDefaultConfig` and `doubleTap_whenZoomed_resetsZoom` — regression: existing double-tap zoom/reset still works.
- `singleTap_invokesOnTapCallback` — new: a single tap fires `onTap`.
- `singleTap_invokesOnTap_notParentClickable` — new: `onTap` fires while the parent clickable stays silent (documents the intended replacement).
- `singleTap_reachesParent_whenTapHandlingDisabled` — regression: with tap handling off, a single tap still bubbles to the parent.

All 5 pass locally. All targets (android/desktop/ios/macos/wasm) compile.

## Notes

- Adds `org.jetbrains.compose.ui:ui-test-junit4` and the host `skiko-awt-runtime` (classifier detected per host, so CI/Linux works) as `desktopTest`-only dependencies.
- Test compiles were excluded from explicit-API mode in the module build, matching `landscapist-core`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional single-tap handling to zoomable content, so apps can react to taps while zoom gestures are enabled.
  * Improved desktop UI test support across host environments and added compose UI test libraries.
* **Bug Fixes**
  * Double-tap zoom behavior is now covered by tests, including reset behavior when zoomed in.
  * Tap handling now correctly prevents parent click targets from receiving taps when zoom gestures consume them.
* **Tests**
  * Added desktop Compose UI tests for tap and zoom interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->