### PR TITLE
chore(zoomable): update tracked API dump signatures

### DIFF
--- a/landscapist-zoomable/api/android/landscapist-zoomable.api
+++ b/landscapist-zoomable/api/android/landscapist-zoomable.api
@@ -90,16 +90,18 @@ public final class com/skydoves/landscapist/zoomable/ZoomablePainterKt {
 public final class com/skydoves/landscapist/zoomable/ZoomablePlugin : com/skydoves/landscapist/plugins/ImagePlugin$ComposablePlugin {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/skydoves/landscapist/zoomable/ZoomableState;
 	public final fun component2 ()Z
 	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun component4 ()Lkotlin/jvm/functions/Function1;
 	public fun compose (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-	public final fun copy (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
-	public static synthetic fun copy$default (Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
+	public final fun copy (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
+	public static synthetic fun copy$default (Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnabled ()Z
+	public final fun getOnTap ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnTransformChanged ()Lkotlin/jvm/functions/Function1;
 	public final fun getState ()Lcom/skydoves/landscapist/zoomable/ZoomableState;
 	public fun hashCode ()I
@@ -144,7 +146,7 @@ public final class com/skydoves/landscapist/zoomable/subsampling/ImageRegionDeco
 }
 
 public final class com/skydoves/landscapist/zoomable/subsampling/SubSamplingImageKt {
-	public static final fun SubSamplingImage (Lcom/skydoves/landscapist/zoomable/subsampling/SubSamplingState;Lcom/skydoves/landscapist/zoomable/ZoomableState;Lcom/skydoves/landscapist/zoomable/ZoomableConfig;ZLandroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SubSamplingImage (Lcom/skydoves/landscapist/zoomable/subsampling/SubSamplingState;Lcom/skydoves/landscapist/zoomable/ZoomableState;Lcom/skydoves/landscapist/zoomable/ZoomableConfig;ZLandroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/skydoves/landscapist/zoomable/subsampling/SubSamplingState {

--- a/landscapist-zoomable/api/desktop/landscapist-zoomable.api
+++ b/landscapist-zoomable/api/desktop/landscapist-zoomable.api
@@ -90,16 +90,18 @@ public final class com/skydoves/landscapist/zoomable/ZoomablePainterKt {
 public final class com/skydoves/landscapist/zoomable/ZoomablePlugin : com/skydoves/landscapist/plugins/ImagePlugin$ComposablePlugin {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/skydoves/landscapist/zoomable/ZoomableState;
 	public final fun component2 ()Z
 	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun component4 ()Lkotlin/jvm/functions/Function1;
 	public fun compose (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-	public final fun copy (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
-	public static synthetic fun copy$default (Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
+	public final fun copy (Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
+	public static synthetic fun copy$default (Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;Lcom/skydoves/landscapist/zoomable/ZoomableState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lcom/skydoves/landscapist/zoomable/ZoomablePlugin;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnabled ()Z
+	public final fun getOnTap ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnTransformChanged ()Lkotlin/jvm/functions/Function1;
 	public final fun getState ()Lcom/skydoves/landscapist/zoomable/ZoomableState;
 	public fun hashCode ()I
@@ -143,7 +145,7 @@ public final class com/skydoves/landscapist/zoomable/subsampling/ImageRegionDeco
 }
 
 public final class com/skydoves/landscapist/zoomable/subsampling/SubSamplingImageKt {
-	public static final fun SubSamplingImage (Lcom/skydoves/landscapist/zoomable/subsampling/SubSamplingState;Lcom/skydoves/landscapist/zoomable/ZoomableState;Lcom/skydoves/landscapist/zoomable/ZoomableConfig;ZLandroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SubSamplingImage (Lcom/skydoves/landscapist/zoomable/subsampling/SubSamplingState;Lcom/skydoves/landscapist/zoomable/ZoomableState;Lcom/skydoves/landscapist/zoomable/ZoomableConfig;ZLandroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class com/skydoves/landscapist/zoomable/subsampling/SubSamplingState {


### PR DESCRIPTION
## What

Updates tracked API dump files for `landscapist-zoomable` generated by `apiDump`.

## Changed files

- `landscapist-zoomable/api/android/landscapist-zoomable.api`
- `landscapist-zoomable/api/desktop/landscapist-zoomable.api`

## Why separate PR

This is intentionally split from the Glide bug-fix PR to keep review scope focused and avoid mixing unrelated module changes.

## Validation

Executed successfully:

- `./gradlew apiDump --no-daemon`
- `./gradlew spotlessApply --no-daemon`