### PR TITLE
fix(glide): prevent stale failure callbacks across request swaps

### DIFF
--- a/glide/src/androidTest/kotlin/com/skydoves/landscapist/glide/GlideImageTest.kt
+++ b/glide/src/androidTest/kotlin/com/skydoves/landscapist/glide/GlideImageTest.kt
@@ -18,6 +18,9 @@ package com.skydoves.landscapist.glide
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalView
@@ -185,6 +188,50 @@ internal class GlideImageTest {
     composeTestRule.runOnIdle {
       assertThat(state.size, `is`(1))
       assertThat(state[0], instanceOf(GlideImageState.Failure::class.java))
+    }
+  }
+
+  @Test
+  fun staleFailure_fromPreviousRequest_doesNotOverrideLatestSuccess() {
+    val terminalStatesForLatestModel = ArrayList<GlideImageState>()
+    val latestModel = android.R.drawable.ic_dialog_info
+    var imageModel by mutableStateOf<Any?>("https://landscapist.invalid/should-fail.jpg")
+
+    composeTestRule.setContent {
+      GlideImage(
+        imageModel = { imageModel },
+        modifier = Modifier
+          .size(128.dp, 128.dp)
+          .testTag(TAG_GLIDE),
+        imageOptions = ImageOptions(contentScale = ContentScale.Crop),
+        onImageStateChanged = { state ->
+          if (
+            imageModel == latestModel &&
+            (state is GlideImageState.Success || state is GlideImageState.Failure)
+          ) {
+            terminalStatesForLatestModel.add(state)
+          }
+        },
+      )
+    }
+
+    composeTestRule.runOnIdle {
+      imageModel = latestModel
+    }
+
+    composeTestRule.waitUntil(10_000) {
+      terminalStatesForLatestModel.isNotEmpty()
+    }
+
+    composeTestRule.runOnIdle {
+      assertThat(
+        terminalStatesForLatestModel.first(),
+        instanceOf(GlideImageState.Success::class.java),
+      )
+      val hasFailureForLatestModel = terminalStatesForLatestModel.any {
+        it is GlideImageState.Failure
+      }
+      assertThat(hasFailureForLatestModel, `is`(false))
     }
   }
 }

--- a/glide/src/main/kotlin/com/skydoves/landscapist/glide/FlowCustomTarget.kt
+++ b/glide/src/main/kotlin/com/skydoves/landscapist/glide/FlowCustomTarget.kt
@@ -46,8 +46,6 @@ internal class FlowCustomTarget constructor(
 
   private val sizeReadyCallbacks = mutableListOf<SizeReadyCallback>()
 
-  private var failException: Throwable? = null
-
   /** onResourceReady will be handled by [FlowRequestListener]. */
   override fun onResourceReady(resource: Any, transition: Transition<in Any>?) = Unit
 
@@ -55,13 +53,7 @@ internal class FlowCustomTarget constructor(
     producerScope?.trySendBlocking(ImageLoadState.Loading)
   }
 
-  override fun onLoadFailed(errorDrawable: Drawable?) {
-    producerScope?.trySendBlocking(
-      ImageLoadState.Failure(
-        data = errorDrawable,
-        reason = failException,
-      ),
-    )
+  override fun onLoadFailed(ignoredErrorDrawable: Drawable?) {
     producerScope?.channel?.close()
   }
 
@@ -118,10 +110,6 @@ internal class FlowCustomTarget constructor(
 
   fun setProducerScope(producerScope: ProducerScope<ImageLoadState>) {
     this.producerScope = producerScope
-  }
-
-  fun updateFailException(throwable: Throwable?) {
-    failException = throwable
   }
 
   private val Constraints.inferredIntSize: IntSize

--- a/glide/src/main/kotlin/com/skydoves/landscapist/glide/FlowRequestListener.kt
+++ b/glide/src/main/kotlin/com/skydoves/landscapist/glide/FlowRequestListener.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.channels.trySendBlocking
  */
 internal class FlowRequestListener(
   private val producerScope: ProducerScope<ImageLoadState>,
-  private val failException: (Throwable?) -> Unit,
 ) : RequestListener<Any> {
 
   override fun onLoadFailed(
@@ -37,9 +36,15 @@ internal class FlowRequestListener(
     target: Target<Any>,
     isFirstResource: Boolean,
   ): Boolean {
-    failException.invoke(e)
-    // return false so that the load failed will handle this.
-    return false
+    producerScope.trySendBlocking(
+      ImageLoadState.Failure(
+        data = null,
+        reason = e,
+      ),
+    )
+    producerScope.channel.close()
+    // return true so target callbacks don't emit into a different active request scope.
+    return true
   }
 
   override fun onResourceReady(

--- a/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
+++ b/glide/src/main/kotlin/com/skydoves/landscapist/glide/GlideImage.kt
@@ -310,9 +310,7 @@ private fun GlideImage(
       callbackFlow {
         target.setProducerScope(this)
 
-        val flowRequestListener = FlowRequestListener(this) {
-          target.updateFailException(it)
-        }
+        val flowRequestListener = FlowRequestListener(this)
 
         // start the image request into the target.
         val typedBuilder = requestManager.buildRequestBuilder(


### PR DESCRIPTION
## What

This PR fixes a stale-state issue in the Glide integration where a failure callback from an earlier request could affect the currently active request state.

## Changes

- Emit failure state directly from `FlowRequestListener.onLoadFailed(...)`.
- Close the active flow channel in the same request-scoped failure path.
- Return `true` from Glide `onLoadFailed(...)` to prevent duplicate/late target-level failure routing.
- Remove target-side failure backchannel (`failException` / `updateFailException`) from `FlowCustomTarget`.
- Add a regression instrumentation test:
  - `staleFailure_fromPreviousRequest_doesNotOverrideLatestSuccess`
  - file: `glide/src/androidTest/kotlin/com/skydoves/landscapist/glide/GlideImageTest.kt`

## Why

`FlowCustomTarget` can be reused across recompositions. When failure propagation depends on target-side mutable state, late callbacks from previous requests can leak into the active request flow.  
By handling failures in `FlowRequestListener` (request-scoped), terminal states stay aligned to the current request.

## Validation

Executed successfully:

- `./gradlew :glide:compileDebugKotlin --no-daemon`
- `./gradlew :glide:testDebugUnitTest --no-daemon`
- `./gradlew :glide:compileDebugAndroidTestKotlin --no-daemon`
- `./gradlew spotlessApply --no-daemon`
- `./gradlew apiDump --no-daemon`

## Risk

Low-to-medium. Scope is limited to Glide failure-path state propagation and includes regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where an earlier failed image request could override a later successful result.
  * Improved image loading state handling so the latest image selection is reflected correctly, even when previous requests fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->