### PR TITLE
Fix documentation typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -865,7 +865,7 @@ GlideImage(
   previewPlaceholder = painterResource(id = R.drawable.poster)
 )
 ```
-> **Note**: You can also use the the `previewPlaceholder` parameter for **`CoilImage`** and **`FrescoImage`**.
+> **Note**: You can also use the `previewPlaceholder` parameter for **`CoilImage`** and **`FrescoImage`**.
 
 ## ImageComponent and ImagePlugin
 


### PR DESCRIPTION
Small documentation typo noticed in the README:

- `README.md`: "use the the `previewPlaceholder` parameter" -> "use the `previewPlaceholder` parameter"

Documentation only; no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated article in the preview placeholder note for `CoilImage` and `FrescoImage`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->