### PR TITLE
Update the Compose stability baseline

### DIFF
--- a/coil/stability/coil-debug.stability
+++ b/coil/stability/coil-debug.stability
@@ -60,14 +60,14 @@ private fun com.skydoves.landscapist.coil.CoilThumbnail(requestSize: androidx.co
 
 @Composable
 public fun com.skydoves.landscapist.coil.LocalCoilProvider.getCoilImageLoader(): coil.ImageLoader
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: com.skydoves.landscapist.coil.CoilImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.coil.CoilImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -75,7 +75,7 @@ public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: co
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: android.content.Context, imageLoader: coil.ImageLoader, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - imageLoader: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -85,8 +85,8 @@ internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: andr
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberRequestWithConstraints(request: coil.request.ImageRequest, imageOptions: com.skydoves.landscapist.ImageOptions): coil.request.ImageRequest
   skippable: false
-  restartable: true
+  restartable: false
   params:
-    - request: UNSTABLE (has mutable properties or unstable members)
+    - request: UNSTABLE (cross-module type without @Stable/@Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
 

--- a/coil/stability/coil-release.stability
+++ b/coil/stability/coil-release.stability
@@ -60,14 +60,14 @@ private fun com.skydoves.landscapist.coil.CoilThumbnail(requestSize: androidx.co
 
 @Composable
 public fun com.skydoves.landscapist.coil.LocalCoilProvider.getCoilImageLoader(): coil.ImageLoader
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: com.skydoves.landscapist.coil.CoilImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.coil.CoilImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -75,7 +75,7 @@ public fun com.skydoves.landscapist.coil.rememberCoilImageState(initialState: co
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: android.content.Context, imageLoader: coil.ImageLoader, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - imageLoader: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -85,8 +85,8 @@ internal fun com.skydoves.landscapist.coil.rememberImageSourceFile(context: andr
 @Composable
 internal fun com.skydoves.landscapist.coil.rememberRequestWithConstraints(request: coil.request.ImageRequest, imageOptions: com.skydoves.landscapist.ImageOptions): coil.request.ImageRequest
   skippable: false
-  restartable: true
+  restartable: false
   params:
-    - request: UNSTABLE (has mutable properties or unstable members)
+    - request: UNSTABLE (cross-module type without @Stable/@Immutable)
     - imageOptions: STABLE (marked @Stable or @Immutable)
 

--- a/fresco/stability/fresco-debug.stability
+++ b/fresco/stability/fresco-debug.stability
@@ -43,29 +43,29 @@ private fun com.skydoves.landscapist.fresco.FrescoImageThumbnail(requestSize: an
 
 @Composable
 public fun com.skydoves.landscapist.fresco.LocalFrescoProvider.getFrescoImageRequest(imageUrl: kotlin.String?): com.facebook.imagepipeline.request.ImageRequestBuilder
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
     - imageUrl: STABLE (class with no mutable properties)
 
 @Composable
 internal fun com.skydoves.landscapist.fresco.rememberCloseableRef(ref: com.facebook.common.references.CloseableReference<T of com.skydoves.landscapist.fresco.rememberCloseableRef>): T of com.skydoves.landscapist.fresco.rememberCloseableRef
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - ref: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState: com.skydoves.landscapist.fresco.FrescoImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.fresco.FrescoImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.toFrescoImageState(): com.skydoves.landscapist.fresco.FrescoImageState
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 

--- a/fresco/stability/fresco-release.stability
+++ b/fresco/stability/fresco-release.stability
@@ -43,29 +43,29 @@ private fun com.skydoves.landscapist.fresco.FrescoImageThumbnail(requestSize: an
 
 @Composable
 public fun com.skydoves.landscapist.fresco.LocalFrescoProvider.getFrescoImageRequest(imageUrl: kotlin.String?): com.facebook.imagepipeline.request.ImageRequestBuilder
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
     - imageUrl: STABLE (class with no mutable properties)
 
 @Composable
 internal fun com.skydoves.landscapist.fresco.rememberCloseableRef(ref: com.facebook.common.references.CloseableReference<T of com.skydoves.landscapist.fresco.rememberCloseableRef>): T of com.skydoves.landscapist.fresco.rememberCloseableRef
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - ref: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.rememberFrescoImageState(initialState: com.skydoves.landscapist.fresco.FrescoImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.fresco.FrescoImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
 
 @Composable
 public fun com.skydoves.landscapist.fresco.toFrescoImageState(): com.skydoves.landscapist.fresco.FrescoImageState
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 

--- a/glide/stability/glide-debug.stability
+++ b/glide/stability/glide-debug.stability
@@ -50,26 +50,26 @@ private fun com.skydoves.landscapist.glide.GlideThumbnail(requestSize: androidx.
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestBuilder(): com.bumptech.glide.RequestBuilder<*>
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestManager(): com.bumptech.glide.RequestManager
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestOptions(): com.bumptech.glide.request.RequestOptions
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: com.skydoves.landscapist.glide.GlideImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.glide.GlideImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -77,7 +77,7 @@ public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: 
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: android.content.Context, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -86,7 +86,7 @@ internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: and
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberTarget(target: com.skydoves.landscapist.glide.FlowCustomTarget, imageOptions: com.skydoves.landscapist.ImageOptions, clearTarget: kotlin.Boolean): com.skydoves.landscapist.glide.FlowCustomTarget
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - target: UNSTABLE (has mutable properties or unstable members)
     - imageOptions: STABLE (marked @Stable or @Immutable)

--- a/glide/stability/glide-release.stability
+++ b/glide/stability/glide-release.stability
@@ -50,26 +50,26 @@ private fun com.skydoves.landscapist.glide.GlideThumbnail(requestSize: androidx.
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestBuilder(): com.bumptech.glide.RequestBuilder<*>
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestManager(): com.bumptech.glide.RequestManager
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.LocalGlideProvider.getGlideRequestOptions(): com.bumptech.glide.request.RequestOptions
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
   params:
 
 @Composable
 public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: com.skydoves.landscapist.glide.GlideImageState, key: kotlin.Any?): androidx.compose.runtime.MutableState<com.skydoves.landscapist.glide.GlideImageState>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - initialState: STABLE (marked @Stable or @Immutable)
     - key: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -77,7 +77,7 @@ public fun com.skydoves.landscapist.glide.rememberGlideImageState(initialState: 
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: android.content.Context, imageModel: kotlin.Any?, dataSource: com.skydoves.landscapist.DataSource?): androidx.compose.runtime.State<java.io.File?>
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - context: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - imageModel: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -86,7 +86,7 @@ internal fun com.skydoves.landscapist.glide.rememberImageSourceFile(context: and
 @Composable
 internal fun com.skydoves.landscapist.glide.rememberTarget(target: com.skydoves.landscapist.glide.FlowCustomTarget, imageOptions: com.skydoves.landscapist.ImageOptions, clearTarget: kotlin.Boolean): com.skydoves.landscapist.glide.FlowCustomTarget
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - target: UNSTABLE (has mutable properties or unstable members)
     - imageOptions: STABLE (marked @Stable or @Immutable)

--- a/landscapist-transformation/stability/landscapist-transformation-debug.stability
+++ b/landscapist-transformation/stability/landscapist-transformation-debug.stability
@@ -7,7 +7,7 @@
 @Composable
 public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin.compose(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, painter: androidx.compose.ui.graphics.painter.Painter): androidx.compose.ui.graphics.painter.Painter
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -15,7 +15,7 @@ public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin
 @Composable
 internal fun com.skydoves.landscapist.transformation.blur.rememberBlurPainter(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, radius: kotlin.Int): androidx.compose.ui.graphics.painter.Painter
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - radius: STABLE (primitive type)

--- a/landscapist-transformation/stability/landscapist-transformation-release.stability
+++ b/landscapist-transformation/stability/landscapist-transformation-release.stability
@@ -7,7 +7,7 @@
 @Composable
 public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin.compose(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, painter: androidx.compose.ui.graphics.painter.Painter): androidx.compose.ui.graphics.painter.Painter
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - painter: UNKNOWN (interface or non-final class; concrete implementation unknown)
@@ -15,7 +15,7 @@ public fun com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin
 @Composable
 internal fun com.skydoves.landscapist.transformation.blur.rememberBlurPainter(imageBitmap: androidx.compose.ui.graphics.ImageBitmap, radius: kotlin.Int): androidx.compose.ui.graphics.painter.Painter
   skippable: false
-  restartable: true
+  restartable: false
   params:
     - imageBitmap: UNKNOWN (interface or non-final class; concrete implementation unknown)
     - radius: STABLE (primitive type)


### PR DESCRIPTION
`stabilityCheck` has been failing in `coil`, `glide`, `fresco` and `landscapist-transformation` since before 2.12.0. This regenerates the baseline with `./gradlew stabilityDump`.

### What changed, and why it is safe

All 16 changed entries are composables that **return a value**, and those can be neither skippable nor restartable: the caller needs the return value, so the compiler cannot skip or restart them independently. The recorded baseline claimed they were, the analyzer now reports it correctly.

```
public fun LocalGlideProvider.getGlideRequestManager(): RequestManager
-  skippable: true
-  restartable: true
+  skippable: false
+  restartable: false
```

**No Unit returning composable changed**, so nothing here masks a real recomposition regression. Verified by extracting every changed signature from the diff and checking each one has a return type:

```
changed composables: 16
returning Unit (would be a real regression): 0
```

One `coil` entry also gains a more precise explanation for an unstable parameter, `cross-module type without @Stable/@Immutable` instead of `has mutable properties or unstable members`, with the same verdict.

### Verification

`stabilityCheck`, `spotlessCheck` and `apiCheck` pass. Only `.stability` files change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Compose stability metadata across image-loading and transformation integrations.
  * Several composables are now classified as non-restartable, with selected functions also classified as non-skippable.
  * Function signatures and parameter definitions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->