### PR TITLE
Render decoded images on desktop

### DIFF
--- a/landscapist-image/src/darwinMain/kotlin/com/skydoves/landscapist/image/PlatformImage.darwin.kt
+++ b/landscapist-image/src/darwinMain/kotlin/com/skydoves/landscapist/image/PlatformImage.darwin.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.IntSize
+
+/** Apple and Web decode straight to the shared skia types, so there is nothing extra to bridge. */
+internal actual fun platformImageBitmapOrNull(data: Any?): ImageBitmap? = null
+
+internal actual fun platformImageSizeOrNull(data: Any?): IntSize? = null

--- a/landscapist-image/src/desktopMain/kotlin/com/skydoves/landscapist/image/PlatformImage.desktop.kt
+++ b/landscapist-image/src/desktopMain/kotlin/com/skydoves/landscapist/image/PlatformImage.desktop.kt
@@ -1,0 +1,28 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.toComposeImageBitmap
+import androidx.compose.ui.unit.IntSize
+import java.awt.image.BufferedImage
+
+/** Desktop decodes through ImageIO, so its decoded images arrive as [BufferedImage]. */
+internal actual fun platformImageBitmapOrNull(data: Any?): ImageBitmap? =
+  (data as? BufferedImage)?.toComposeImageBitmap()
+
+internal actual fun platformImageSizeOrNull(data: Any?): IntSize? =
+  (data as? BufferedImage)?.let { IntSize(it.width, it.height) }

--- a/landscapist-image/src/desktopTest/kotlin/com/skydoves/landscapist/image/DesktopBufferedImageTest.kt
+++ b/landscapist-image/src/desktopTest/kotlin/com/skydoves/landscapist/image/DesktopBufferedImageTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.image
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.core.ImageRequest
+import com.skydoves.landscapist.core.Landscapist
+import com.skydoves.landscapist.core.model.CachePolicy
+import com.skydoves.landscapist.core.model.ImageResult
+import com.skydoves.landscapist.core.network.FetchResult
+import com.skydoves.landscapist.core.network.ImageFetcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * The desktop decoder produces a [BufferedImage], so the painter and the bitmap converter have to
+ * understand one. Issue #982.
+ */
+@OptIn(ExperimentalTestApi::class)
+class DesktopBufferedImageTest {
+
+  private val url = "https://example.com/photo.png"
+
+  /** A 4x2 solid red PNG, encoded the way a server would send it. */
+  private val png: ByteArray = run {
+    val image = BufferedImage(4, 2, BufferedImage.TYPE_INT_ARGB)
+    for (x in 0 until 4) {
+      for (y in 0 until 2) {
+        image.setRGB(x, y, 0xFFFF0000.toInt())
+      }
+    }
+    ByteArrayOutputStream().use { out ->
+      ImageIO.write(image, "png", out)
+      out.toByteArray()
+    }
+  }
+
+  private inner class PngFetcher : ImageFetcher {
+    override fun canHandle(model: Any?): Boolean = true
+    override suspend fun fetch(request: ImageRequest): FetchResult =
+      FetchResult.Success(data = png, mimeType = "image/png")
+  }
+
+  /** No decoder override, so this exercises the real DesktopImageDecoder. */
+  private fun newLoader(): Landscapist = Landscapist.builder().fetcher(PngFetcher()).build()
+
+  private fun request() = ImageRequest.builder()
+    .model(url)
+    .diskCachePolicy(CachePolicy.DISABLED)
+    .size(4, 2)
+    .build()
+
+  private fun Landscapist.awaitDecoded(): Any {
+    val result = runBlocking { load(request()).first { it is ImageResult.Success } }
+    return assertNotNull(assertIs<ImageResult.Success>(result).data)
+  }
+
+  @Test
+  fun `the desktop decoder really does hand back a BufferedImage`() {
+    assertIs<BufferedImage>(newLoader().awaitDecoded())
+  }
+
+  @Test
+  fun `a decoded desktop image converts to an ImageBitmap`() {
+    val bitmap = assertNotNull(
+      convertToImageBitmap(newLoader().awaitDecoded()),
+      "convertToImageBitmap dropped the decoded image, so palette and painter plugins never run",
+    )
+
+    assertEquals(4, bitmap.width)
+    assertEquals(2, bitmap.height)
+  }
+
+  @Test
+  fun `a decoded desktop image is drawn rather than dropped`() {
+    val landscapist = newLoader()
+    landscapist.awaitDecoded()
+
+    var painter: Painter? = null
+    runComposeUiTest {
+      setContent {
+        LandscapistImage(
+          imageModel = { url },
+          landscapist = landscapist,
+          modifier = Modifier.size(100.dp),
+          requestBuilder = { diskCachePolicy(CachePolicy.DISABLED) },
+          success = { _, loaded -> painter = loaded },
+        )
+      }
+    }
+
+    val loaded = assertNotNull(painter, "the image never reached the success slot")
+    assertTrue(
+      loaded !is EmptyPainter,
+      "the desktop image fell through to EmptyPainter, so nothing is drawn",
+    )
+  }
+}

--- a/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/ImageBitmapConverter.skia.kt
+++ b/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/ImageBitmapConverter.skia.kt
@@ -22,7 +22,7 @@ import org.jetbrains.skia.Image
 
 /**
  * Skia implementation that converts [RawImageData] to [ImageBitmap].
- * Used by Apple (iOS/macOS) and Wasm platforms.
+ * Desktop decodes to its own image type, which [platformImageBitmapOrNull] handles.
  */
 public actual fun convertToImageBitmap(data: Any): ImageBitmap? {
   return when (data) {
@@ -35,16 +35,15 @@ public actual fun convertToImageBitmap(data: Any): ImageBitmap? {
       }
     }
     is ImageBitmap -> data
-    else -> null
+    else -> platformImageBitmapOrNull(data)
   }
 }
 
 /**
- * Skia implementation: checks if data is an ImageBitmap.
- * Note: Skia platforms typically use RawImageData, not pre-decoded bitmaps.
+ * Skia implementation: checks if data is an ImageBitmap, or the target's own decoded image type.
  */
 public actual fun isBitmapType(data: Any?): Boolean {
-  return data is ImageBitmap
+  return data is ImageBitmap || platformImageSizeOrNull(data) != null
 }
 
 /**
@@ -53,7 +52,7 @@ public actual fun isBitmapType(data: Any?): Boolean {
 public actual fun getBitmapWidth(data: Any?): Int {
   return when (data) {
     is ImageBitmap -> data.width
-    else -> 0
+    else -> platformImageSizeOrNull(data)?.width ?: 0
   }
 }
 
@@ -63,6 +62,6 @@ public actual fun getBitmapWidth(data: Any?): Int {
 public actual fun getBitmapHeight(data: Any?): Int {
   return when (data) {
     is ImageBitmap -> data.height
-    else -> 0
+    else -> platformImageSizeOrNull(data)?.height ?: 0
   }
 }

--- a/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.skia.kt
+++ b/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/LandscapistPainter.skia.kt
@@ -28,7 +28,7 @@ import org.jetbrains.skia.Image
 
 /**
  * Creates and remembers a [Painter] from Skia Bitmap, RawImageData, or ImageBitmap.
- * Used by Apple (iOS/macOS) and Wasm platforms.
+ * Desktop decodes to its own image type, which [platformImageBitmapOrNull] handles.
  */
 @Composable
 public actual fun rememberLandscapistPainter(data: Any?): Painter {
@@ -44,7 +44,7 @@ public actual fun rememberLandscapistPainter(data: Any?): Painter {
         }
       }
       is ImageBitmap -> BitmapPainter(data)
-      else -> EmptyPainter
+      else -> platformImageBitmapOrNull(data)?.let { BitmapPainter(it) } ?: EmptyPainter
     }
   }
 }

--- a/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/PlatformImage.skia.kt
+++ b/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/PlatformImage.skia.kt
@@ -1,0 +1,38 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.image
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.unit.IntSize
+
+/**
+ * Bridges the decoded image type a single skia target adds on top of the shared ones.
+ *
+ * The skia source set covers desktop as well as Apple and Web, and desktop decodes through ImageIO
+ * to a `java.awt.image.BufferedImage`, which the other targets have no notion of. Naming it here
+ * would not compile for them, so each target answers for its own type.
+ *
+ * @return The Compose bitmap for [data], or null when it is not this target's image type.
+ */
+internal expect fun platformImageBitmapOrNull(data: Any?): ImageBitmap?
+
+/**
+ * The pixel size of [data] when it is this target's image type, or null.
+ *
+ * Kept separate from [platformImageBitmapOrNull] because reading a size is free, while converting
+ * is a pixel copy, and the callers that only need the size run on every composition.
+ */
+internal expect fun platformImageSizeOrNull(data: Any?): IntSize?


### PR DESCRIPTION
Fixes #982.

`DesktopImageDecoder` decodes through ImageIO and hands back a `BufferedImage`. The skia painter and bitmap converter only knew skia `Bitmap`, `RawImageData` and `ImageBitmap`, so a `BufferedImage` fell through to `EmptyPainter`. Every image loaded through the pipeline on desktop drew nothing, and `convertToImageBitmap` returned null, so palette and painter plugins never ran either.

Reproduced first, with the real decoder rather than a stub:

```
FAIL a decoded desktop image converts to an ImageBitmap
     -> convertToImageBitmap dropped the decoded image, so palette and painter plugins never run
FAIL a decoded desktop image is drawn rather than dropped
     -> the desktop image fell through to EmptyPainter, so nothing is drawn
pass the desktop decoder really does hand back a BufferedImage
```

### Fix

The skia source set covers desktop as well as Apple and Web, so it cannot name `java.awt.image.BufferedImage`. Two internal hooks let each target answer for its own decoded image type:

* `platformImageBitmapOrNull` converts it, and desktop is the only target with something to convert.
* `platformImageSizeOrNull` reads its size, kept separate because reading a size is free while converting is a pixel copy, and the size callers run on every composition.

A `BufferedImage` passed as the image model now takes the pre-decoded fast path too, since `isBitmapType` recognizes it.

Both hooks are internal, so the published signatures are untouched and the api dump is unchanged.

### Verification

The three tests above pass, and 295 desktop tests pass overall. `assemble`, `spotlessCheck`, `apiCheck` and `testDebugUnitTest` pass, and `landscapist-image` compiles for android, desktop, iosArm64, macosArm64 and wasmJs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop-decoded images are now converted and displayed correctly as Compose images.
  * Image dimensions are now detected correctly for desktop image data.
  * Unsupported image formats continue to fall back safely without disrupting rendering.

* **Tests**
  * Added coverage for desktop image decoding, conversion, sizing, and successful rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->