### PR TITLE
Cut the remaining core and Compose hot paths

### DIFF
--- a/benchmark-engine/build.gradle.kts
+++ b/benchmark-engine/build.gradle.kts
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 plugins {
   kotlin("jvm")
   application
+  alias(libs.plugins.jetbrains.compose)
+  alias(libs.plugins.compose.compiler)
   id("landscapist.spotless")
 }
 
@@ -34,7 +36,11 @@ application {
 
 dependencies {
   implementation(project(":landscapist-core"))
+  implementation(project(":landscapist-image"))
   implementation(libs.coil3)
+  implementation("io.coil-kt.coil3:coil-compose:${libs.versions.coil3.get()}")
+  implementation(compose.desktop.currentOs)
+  implementation(compose.foundation)
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okio)
   runtimeOnly("org.jetbrains.skiko:skiko-awt-runtime-${skikoHostTarget()}:${libs.versions.skiko.get()}")
@@ -52,6 +58,11 @@ fun skikoHostTarget(): String {
   val archPart = if (arch.contains("aarch64") || arch.contains("arm64")) "arm64" else "x64"
   return "$osPart-$archPart"
 }
+
+// Nothing consumes a distribution of a benchmark, and building one on every assemble both wastes
+// CI time and trips over duplicate jars in the Compose dependency graph. `run` is the entry point.
+tasks.named("distTar") { enabled = false }
+tasks.named("distZip") { enabled = false }
 
 tasks.withType<KotlinJvmCompile>().configureEach {
   compilerOptions {

--- a/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/ComposeBenchmark.kt
+++ b/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/ComposeBenchmark.kt
@@ -1,0 +1,184 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.benchmark
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.ImageComposeScene
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext
+import com.skydoves.landscapist.core.Landscapist
+import com.skydoves.landscapist.core.model.ImageResult
+import com.skydoves.landscapist.image.LandscapistImage
+import com.skydoves.landscapist.image.LocalLandscapist
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import coil3.request.ImageRequest as CoilImageRequest
+
+/**
+ * The Compose layer, measured the way a user experiences it: how long from entering composition to
+ * a frame that actually has the image in it.
+ *
+ * Rendering happens through [ImageComposeScene], which composes, lays out and rasterizes offscreen,
+ * so no window or display is needed. Both libraries are given a warm memory cache first, because
+ * that is the state a list is in once it has been scrolled through, and it is the state where a
+ * loader either draws immediately or shows a frame of nothing.
+ */
+internal fun composeComparison() {
+  val landscapistCounter = FetchCounter()
+  val coilCounter = FetchCounter()
+  val landscapist = newLandscapist(landscapistCounter)
+  val coil = newCoil(coilCounter)
+  val models = List(ITEM_COUNT) { "https://example.com/list-item-$it.jpg" }
+
+  // Warm both caches, which is what a second pass over a list sees.
+  runBlocking {
+    for (model in models) {
+      landscapist.load(landscapistRequest(model, ITEM_SIZE)).first { it is ImageResult.Success }
+      coil.execute(coilRequest(model, ITEM_SIZE))
+    }
+  }
+
+  val warmups = 20
+  val iterations = 60
+
+  val landscapistFrames = measure("landscapist", warmups, iterations) {
+    renderOnce { LandscapistList(landscapist, models) }
+  }
+  settle()
+  val coilFrames = measure("coil", warmups, iterations) {
+    renderOnce { CoilList(coil, models) }
+  }
+
+  report("first frame, $ITEM_COUNT cached images", landscapistFrames, coilFrames)
+
+  val landscapistBytes = allocatedBytes {
+    repeat(iterations) { renderOnce { LandscapistList(landscapist, models) } }
+  }
+  val coilBytes = allocatedBytes {
+    repeat(iterations) { renderOnce { CoilList(coil, models) } }
+  }
+  // The scene itself composes, lays out and rasterizes, so measure that floor and subtract it.
+  val emptyBytes = allocatedBytes {
+    repeat(iterations) { renderOnce { EmptyList() } }
+  }
+  val floor = emptyBytes / iterations
+  // Where the bytes go: the framework around the image versus drawing the image itself.
+  val shellBytes = allocatedBytes {
+    repeat(iterations) { renderOnce { LandscapistShellList(landscapist, models) } }
+  }
+  println("allocation per first frame of $ITEM_COUNT images")
+  println("  empty scene    ${floor.formatBytes()}  (the floor, subtracted below)")
+  println("  landscapist    ${(landscapistBytes / iterations - floor).formatBytes()}")
+  println("  coil           ${(coilBytes / iterations - floor).formatBytes()}")
+  val shell = (shellBytes / iterations - floor).formatBytes()
+  println("    landscapist with an empty success slot (framework only): $shell")
+  println()
+}
+
+private const val ITEM_COUNT = 20
+private const val ITEM_SIZE = 128
+
+/**
+ * Composes, lays out and rasterizes one frame.
+ *
+ * The scene is created and closed per measurement on purpose: a composable that resolves its image
+ * on first composition is exactly what is being measured, and reusing a scene would hide it.
+ */
+private inline fun renderOnce(crossinline content: @Composable () -> Unit) {
+  val scene = ImageComposeScene(
+    width = ITEM_SIZE,
+    height = ITEM_SIZE * ITEM_COUNT,
+    density = Density(1f),
+    coroutineContext = Dispatchers.Unconfined,
+    content = { content() },
+  )
+  try {
+    scene.render(0L).close()
+  } finally {
+    scene.close()
+  }
+}
+
+@Composable
+private fun EmptyList() {
+  Column {
+    repeat(ITEM_COUNT) {
+      Box(Modifier.size(ITEM_SIZE.dp))
+    }
+  }
+}
+
+@Composable
+private fun LandscapistList(
+  landscapist: Landscapist,
+  models: List<String>,
+) {
+  CompositionLocalProvider(LocalLandscapist provides landscapist) {
+    Column {
+      for (model in models) {
+        LandscapistImage(
+          imageModel = { model },
+          landscapist = landscapist,
+          modifier = Modifier.size(ITEM_SIZE.dp),
+        )
+      }
+    }
+  }
+}
+
+/** The same composable with nothing drawn, separating framework cost from drawing cost. */
+@Composable
+private fun LandscapistShellList(
+  landscapist: Landscapist,
+  models: List<String>,
+) {
+  Column {
+    for (model in models) {
+      LandscapistImage(
+        imageModel = { model },
+        landscapist = landscapist,
+        modifier = Modifier.size(ITEM_SIZE.dp),
+        success = { _, _ -> },
+      )
+    }
+  }
+}
+
+@Composable
+private fun CoilList(imageLoader: ImageLoader, models: List<String>) {
+  Column {
+    for (model in models) {
+      AsyncImage(
+        model = CoilImageRequest.Builder(LocalPlatformContext.current)
+          .data(model)
+          .size(ITEM_SIZE, ITEM_SIZE)
+          .build(),
+        contentDescription = null,
+        imageLoader = imageLoader,
+        modifier = Modifier.size(ITEM_SIZE.dp),
+      )
+    }
+  }
+}

--- a/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/DecodeBenchmark.kt
+++ b/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/DecodeBenchmark.kt
@@ -1,0 +1,90 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.benchmark
+
+import com.skydoves.landscapist.core.LandscapistConfig
+import com.skydoves.landscapist.core.decoder.DecodeResult
+import com.skydoves.landscapist.core.decoder.createPlatformDecoder
+import kotlinx.coroutines.runBlocking
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+/**
+ * Each library's real decoder against the same bytes.
+ *
+ * This is the one comparison where the two are genuinely doing different work: Coil decodes through
+ * Skia, landscapist-core through ImageIO. It is reported separately from the engine numbers for
+ * exactly that reason, and it says as much about the two imaging stacks as about the loaders.
+ */
+internal fun decodeComparison() {
+  val photo = syntheticPhoto(4000, 3000)
+  println("decode a ${4000}x${3000} JPEG (${photo.size.toLong().formatBytes()}) down to 400x300")
+
+  val landscapistDecoder = createPlatformDecoder()
+  val config = LandscapistConfig()
+
+  val landscapist = measure("landscapist", warmups = 5, iterations = 25) {
+    runBlocking {
+      val result = landscapistDecoder.decode(photo, "image/jpeg", 400, 300, config)
+      check(result is DecodeResult.Success) { "decode failed: $result" }
+    }
+  }
+  settle()
+
+  val coil = measure("coil (skia)", warmups = 5, iterations = 25) {
+    // What SkiaImageDecoder does: full decode, then a raster to scale into.
+    val image = org.jetbrains.skia.Image.makeFromEncoded(photo)
+    val bitmap = org.jetbrains.skia.Bitmap()
+    bitmap.allocN32Pixels(400, 300)
+    org.jetbrains.skia.Canvas(bitmap).drawImageRect(
+      image,
+      org.jetbrains.skia.Rect.makeWH(image.width.toFloat(), image.height.toFloat()),
+      org.jetbrains.skia.Rect.makeWH(400f, 300f),
+    )
+    bitmap.setImmutable()
+    image.close()
+  }
+
+  report("decode 4000x3000 -> 400x300", landscapist, coil)
+
+  val peakLandscapist = allocatedBytes {
+    runBlocking { landscapistDecoder.decode(photo, "image/jpeg", 400, 300, config) }
+  }
+  println("  allocation for one decode")
+  println("    landscapist    ${peakLandscapist.formatBytes()}")
+  println()
+}
+
+/** A JPEG with enough detail that the encoder cannot collapse it to nothing. */
+private fun syntheticPhoto(width: Int, height: Int): ByteArray {
+  val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+  var seed = 0x9E3779B9.toInt()
+  for (y in 0 until height step 2) {
+    for (x in 0 until width step 2) {
+      seed = seed * 1_664_525 + 1_013_904_223
+      val rgb = seed and 0xFFFFFF
+      image.setRGB(x, y, rgb)
+      if (x + 1 < width) image.setRGB(x + 1, y, rgb)
+      if (y + 1 < height) image.setRGB(x, y + 1, rgb)
+      if (x + 1 < width && y + 1 < height) image.setRGB(x + 1, y + 1, rgb)
+    }
+  }
+  return ByteArrayOutputStream().use { out ->
+    ImageIO.write(image, "jpg", out)
+    out.toByteArray()
+  }
+}

--- a/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/EngineBenchmark.kt
+++ b/benchmark-engine/src/main/kotlin/com/skydoves/landscapist/benchmark/EngineBenchmark.kt
@@ -50,6 +50,8 @@ fun main() {
   allocations()
   coalescing()
   nearIdenticalSizes()
+  decodeComparison()
+  composeComparison()
 
   println("=".repeat(96))
   println("Percentiles over the reported iteration count. Lower is better.")

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/ImageRequest.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/ImageRequest.kt
@@ -55,8 +55,12 @@ public data class ImageRequest(
     private var model: Any? = null
     private var memoryCachePolicy: CachePolicy = CachePolicy.ENABLED
     private var diskCachePolicy: CachePolicy = CachePolicy.ENABLED
-    private var headers: MutableMap<String, String> = mutableMapOf()
-    private var transformations: MutableList<Transformation> = mutableListOf()
+
+    // Left null until something is actually added. Most requests are a URL and a size, and
+    // allocating an empty map and an empty list per request, then copying both in build(), is four
+    // objects for nothing.
+    private var headers: MutableMap<String, String>? = null
+    private var transformations: MutableList<Transformation>? = null
     private var targetWidth: Int? = null
     private var targetHeight: Int? = null
     private var tag: String? = null
@@ -78,24 +82,24 @@ public data class ImageRequest(
 
     /** Adds an HTTP header. */
     public fun addHeader(name: String, value: String): Builder = apply {
-      this.headers[name] = value
+      (this.headers ?: mutableMapOf<String, String>().also { this.headers = it })[name] = value
     }
 
     /** Sets all HTTP headers. */
     public fun headers(headers: Map<String, String>): Builder = apply {
-      this.headers.clear()
-      this.headers.putAll(headers)
+      this.headers = if (headers.isEmpty()) null else LinkedHashMap(headers)
     }
 
     /** Adds a transformation. */
     public fun addTransformation(transformation: Transformation): Builder = apply {
-      this.transformations.add(transformation)
+      (this.transformations ?: mutableListOf<Transformation>().also { this.transformations = it })
+        .add(transformation)
     }
 
     /** Sets all transformations. */
     public fun transformations(transformations: List<Transformation>): Builder = apply {
-      this.transformations.clear()
-      this.transformations.addAll(transformations)
+      this.transformations =
+        if (transformations.isEmpty()) null else transformations.toMutableList()
     }
 
     /** Sets the target size. */
@@ -128,8 +132,8 @@ public data class ImageRequest(
       model = model,
       memoryCachePolicy = memoryCachePolicy,
       diskCachePolicy = diskCachePolicy,
-      headers = headers.toMap(),
-      transformations = transformations.toList(),
+      headers = headers?.toMap().orEmpty(),
+      transformations = transformations?.toList().orEmpty(),
       targetWidth = targetWidth,
       targetHeight = targetHeight,
       tag = tag,

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/Landscapist.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/Landscapist.kt
@@ -160,7 +160,7 @@ public class Landscapist private constructor(
     // 1. Memory cache (instant). Checked per call so a hit never waits on coalescing, and checked
     // before any loading state is emitted so an image already in memory never blinks through one.
     if (request.memoryCachePolicy.readEnabled) {
-      memoryCache[cacheKey]?.let { cached ->
+      readMemoryCache(request, cacheKey)?.let { cached ->
         emit(cached.toSuccess())
         return
       }
@@ -197,8 +197,39 @@ public class Landscapist private constructor(
   public fun peekMemoryCache(request: ImageRequest): ImageResult.Success? {
     if (request.model == null || !request.memoryCachePolicy.readEnabled) return null
     val cacheKey = request.cacheKey()
+    // The peek runs before layout, so there is usually no target size to satisfy and any decoded
+    // variant will do. The correctly sized one replaces it as soon as the real load resolves.
     val cached = memoryCache[cacheKey] ?: memoryCache.getIgnoringSize(cacheKey) ?: return null
     return cached.toSuccess()
+  }
+
+  /**
+   * Reads [request] out of the memory cache, reusing a differently sized variant when it is large
+   * enough to serve this one.
+   *
+   * A layout rarely measures to exactly the same pixel twice. A grid whose columns do not divide
+   * evenly asks for 359, 360 and 361 wide, and keying strictly on the target size makes those three
+   * separate entries and three separate decodes of one image. Accepting an entry that is already at
+   * least as large costs nothing in quality, since it is only ever scaled down to draw.
+   */
+  private fun readMemoryCache(request: ImageRequest, cacheKey: CacheKey): CachedImage? {
+    memoryCache[cacheKey]?.let { return it }
+    val candidate = memoryCache.getIgnoringSize(cacheKey) ?: return null
+    return candidate.takeIf { it.coversRequestedSize(request) }
+  }
+
+  /**
+   * Whether this entry's decoded pixels are at least as many as [request] asked for.
+   *
+   * A pixel of tolerance on each axis absorbs layouts that measure to fractional sizes. An entry
+   * smaller than the request is refused, because scaling it up would be visibly worse than decoding
+   * again.
+   */
+  private fun CachedImage.coversRequestedSize(request: ImageRequest): Boolean {
+    val targetWidth = request.targetWidth.asPixelBound() ?: return true
+    val targetHeight = request.targetHeight.asPixelBound() ?: return true
+    if (originalWidth <= 0 || originalHeight <= 0) return false
+    return originalWidth + 1 >= targetWidth && originalHeight + 1 >= targetHeight
   }
 
   /**
@@ -208,6 +239,9 @@ public class Landscapist private constructor(
    */
   public fun peekMemoryCache(url: String): ImageResult.Success? =
     peekMemoryCache(ImageRequest(model = url))
+
+  /** A target dimension in pixels, or null when the layout left that axis unbounded. */
+  private fun Int?.asPixelBound(): Int? = this?.takeIf { it > 0 && it != Int.MAX_VALUE }
 
   private fun ImageRequest.cacheKey(): CacheKey = CacheKey.create(
     model = model,
@@ -300,7 +334,7 @@ public class Landscapist private constructor(
           val bytes = snapshot.data().buffer().readByteArray()
           val diskPath = snapshot.dataPath.toString()
           when (
-            val decodeResult = scheduleDecodeWithPriority(request) {
+            val decodeResult = scheduleDecodeWithPriority(cacheKey, request) {
               decoder.decode(
                 data = bytes,
                 mimeType = null,
@@ -393,7 +427,7 @@ public class Landscapist private constructor(
     diskPath: String?,
   ): ImageResult {
     return when (
-      val decodeResult = scheduleDecodeWithPriority(request) {
+      val decodeResult = scheduleDecodeWithPriority(cacheKey, request) {
         decoder.decode(
           data = bytes,
           mimeType = mimeType,
@@ -574,18 +608,23 @@ public class Landscapist private constructor(
   /**
    * Schedules a decode operation with priority.
    */
+  /**
+   * Runs [decoder] through the shared decode gate.
+   *
+   * The id is the memory key, which is already built and is genuinely unique. Deriving it from
+   * `model.hashCode()` meant two different URLs at the same target size shared an id, and the
+   * scheduler's active map would drop one of them.
+   */
   private suspend fun <T> scheduleDecodeWithPriority(
+    cacheKey: CacheKey,
     request: ImageRequest,
     decoder: suspend () -> T,
-  ): T {
-    val requestId = "${request.model.hashCode()}_${request.targetWidth}_${request.targetHeight}"
-    return DecodeScheduler.global().schedule(
-      id = requestId,
-      priority = request.priority,
-      tag = request.tag,
-      decoder = decoder,
-    ).await()
-  }
+  ): T = DecodeScheduler.global().schedule(
+    id = cacheKey.memoryKey,
+    priority = request.priority,
+    tag = request.tag,
+    decoder = decoder,
+  ).await()
 
   /**
    * Performs progressive decoding and emits intermediate results.

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/scheduler/DecodeScheduler.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/scheduler/DecodeScheduler.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.concurrent.Volatile
 
 /**
  * A scheduler for prioritized decode operations.
@@ -296,12 +297,17 @@ public class DecodeScheduler(
     /**
      * Global decode scheduler instance.
      */
+    @Volatile
     private var globalScheduler: DecodeScheduler? = null
 
     /**
      * Gets the global decode scheduler, creating it if necessary.
+     *
+     * Read without the lock once it exists: this is called for every decode, and taking a monitor
+     * to re-read a field that stopped changing after the first image made every decoding thread
+     * queue behind the same one.
      */
-    public fun global(): DecodeScheduler = synchronized(globalLock) {
+    public fun global(): DecodeScheduler = globalScheduler ?: synchronized(globalLock) {
       globalScheduler ?: DecodeScheduler().also { globalScheduler = it }
     }
 

--- a/landscapist-core/src/desktopMain/kotlin/com/skydoves/landscapist/core/decoder/ImageDecoder.desktop.kt
+++ b/landscapist-core/src/desktopMain/kotlin/com/skydoves/landscapist/core/decoder/ImageDecoder.desktop.kt
@@ -18,6 +18,7 @@ package com.skydoves.landscapist.core.decoder
 import com.skydoves.landscapist.core.LandscapistConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.awt.RenderingHints
 import java.awt.image.BufferedImage
 import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
@@ -40,38 +41,66 @@ internal class DesktopImageDecoder : ImageDecoder {
     config: LandscapistConfig,
   ): DecodeResult = withContext(Dispatchers.IO) {
     try {
-      val inputStream = ByteArrayInputStream(data)
-      val image = ImageIO.read(inputStream)
-        ?: return@withContext DecodeResult.Error(
-          IllegalArgumentException("Failed to decode image"),
-        )
-
-      val originalWidth = image.width
-      val originalHeight = image.height
-
-      // Calculate target dimensions
-      val (finalWidth, finalHeight) = calculateTargetSize(
-        originalWidth = originalWidth,
-        originalHeight = originalHeight,
-        targetWidth = targetWidth,
-        targetHeight = targetHeight,
-        maxSize = config.maxBitmapSize,
-      )
-
-      // Scale if necessary
-      val finalImage = if (finalWidth != originalWidth || finalHeight != originalHeight) {
-        scaleImage(image, finalWidth, finalHeight)
-      } else {
-        image
-      }
-
-      DecodeResult.Success(
-        bitmap = finalImage,
-        width = finalImage.width,
-        height = finalImage.height,
-      )
+      decodeSubsampled(data, targetWidth, targetHeight, config)
     } catch (e: Exception) {
       DecodeResult.Error(e)
+    }
+  }
+
+  /**
+   * Reads the header, decodes at the nearest power of two above the requested size, then scales the
+   * remainder.
+   *
+   * Decoding the whole image and shrinking it afterwards means a 4000x3000 photo materialises 48 MB
+   * of pixels to produce a thumbnail. ImageIO can skip pixels while it reads, so the full size
+   * raster never exists.
+   */
+  private fun decodeSubsampled(
+    data: ByteArray,
+    targetWidth: Int?,
+    targetHeight: Int?,
+    config: LandscapistConfig,
+  ): DecodeResult {
+    ImageIO.createImageInputStream(ByteArrayInputStream(data)).use { stream ->
+      val readers = ImageIO.getImageReaders(stream)
+      if (!readers.hasNext()) {
+        return DecodeResult.Error(IllegalArgumentException("Failed to decode image"))
+      }
+      val reader = readers.next()
+      try {
+        reader.setInput(stream, true, true)
+        val originalWidth = reader.getWidth(0)
+        val originalHeight = reader.getHeight(0)
+
+        val (finalWidth, finalHeight) = calculateTargetSize(
+          originalWidth = originalWidth,
+          originalHeight = originalHeight,
+          targetWidth = targetWidth,
+          targetHeight = targetHeight,
+          maxSize = config.maxBitmapSize,
+        )
+
+        val param = reader.defaultReadParam
+        val sampleSize = sampleSizeFor(originalWidth, originalHeight, finalWidth, finalHeight)
+        if (sampleSize > 1) {
+          param.setSourceSubsampling(sampleSize, sampleSize, 0, 0)
+        }
+
+        val decoded = reader.read(0, param)
+        val image = if (decoded.width != finalWidth || decoded.height != finalHeight) {
+          scaleImage(decoded, finalWidth, finalHeight)
+        } else {
+          decoded
+        }
+
+        return DecodeResult.Success(
+          bitmap = image,
+          width = image.width,
+          height = image.height,
+        )
+      } finally {
+        reader.dispose()
+      }
     }
   }
 
@@ -93,9 +122,36 @@ internal class DesktopImageDecoder : ImageDecoder {
     val heightRatio = maxH.toFloat() / originalHeight
     val ratio = minOf(widthRatio, heightRatio)
 
-    return (originalWidth * ratio).toInt() to (originalHeight * ratio).toInt()
+    return (originalWidth * ratio).toInt().coerceAtLeast(1) to
+      (originalHeight * ratio).toInt().coerceAtLeast(1)
   }
 
+  /**
+   * The largest power of two the reader can skip by while still producing at least [finalWidth] by
+   * [finalHeight] pixels, so the remaining scale is never an upscale.
+   */
+  private fun sampleSizeFor(
+    originalWidth: Int,
+    originalHeight: Int,
+    finalWidth: Int,
+    finalHeight: Int,
+  ): Int {
+    if (finalWidth <= 0 || finalHeight <= 0) return 1
+    var sampleSize = 1
+    while (
+      originalWidth / (sampleSize * 2) >= finalWidth &&
+      originalHeight / (sampleSize * 2) >= finalHeight
+    ) {
+      sampleSize *= 2
+    }
+    return sampleSize
+  }
+
+  /**
+   * Bilinear rather than [java.awt.Image.SCALE_SMOOTH], which runs an area averaging pipeline that
+   * is roughly an order of magnitude slower. Subsampling has already brought the image to within a
+   * factor of two, so a single bilinear pass loses nothing visible.
+   */
   private fun scaleImage(
     image: BufferedImage,
     targetWidth: Int,
@@ -103,12 +159,12 @@ internal class DesktopImageDecoder : ImageDecoder {
   ): BufferedImage {
     val scaledImage = BufferedImage(targetWidth, targetHeight, BufferedImage.TYPE_INT_ARGB)
     val graphics = scaledImage.createGraphics()
-    graphics.drawImage(
-      image.getScaledInstance(targetWidth, targetHeight, java.awt.Image.SCALE_SMOOTH),
-      0,
-      0,
-      null,
+    graphics.setRenderingHint(
+      RenderingHints.KEY_INTERPOLATION,
+      RenderingHints.VALUE_INTERPOLATION_BILINEAR,
     )
+    graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY)
+    graphics.drawImage(image, 0, 0, targetWidth, targetHeight, null)
     graphics.dispose()
     return scaledImage
   }

--- a/landscapist-image/src/androidMain/kotlin/com/skydoves/landscapist/image/ProvideImageSource.android.kt
+++ b/landscapist-image/src/androidMain/kotlin/com/skydoves/landscapist/image/ProvideImageSource.android.kt
@@ -16,6 +16,7 @@
 package com.skydoves.landscapist.image
 
 import androidx.compose.runtime.Composable
+import com.skydoves.landscapist.LocalImageSourceFile
 import com.skydoves.landscapist.ProvideImageSourceFile
 import java.io.File
 
@@ -28,6 +29,13 @@ public actual fun ProvideImageSource(
   rawData: ByteArray?,
   content: @Composable () -> Unit,
 ) {
+  // Providing a composition local rebuilds the local map for the subtree, and only the
+  // sub-sampling plugins ever read this one. The exists() check is a syscall, so it is skipped too
+  // when there is no path.
+  if (diskCachePath == null && LocalImageSourceFile.current == null) {
+    content()
+    return
+  }
   val file = diskCachePath?.let { File(it) }?.takeIf { it.exists() }
   ProvideImageSourceFile(file = file) {
     content()

--- a/landscapist-image/src/commonMain/kotlin/com/skydoves/landscapist/image/LandscapistImage.kt
+++ b/landscapist-image/src/commonMain/kotlin/com/skydoves/landscapist/image/LandscapistImage.kt
@@ -58,6 +58,8 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import org.jetbrains.compose.resources.DrawableResource
 import org.jetbrains.compose.resources.painterResource
+import com.skydoves.landscapist.DataSource as PublicDataSource
+import com.skydoves.landscapist.core.model.DataSource as CoreDataSource
 
 /**
  * Loads and displays an image using the Landscapist core image loading engine.
@@ -108,12 +110,16 @@ public fun LandscapistImage(
     }.build()
   }
 
-  // Check for CrossfadePlugin to enable crossfade animation
-  val crossfadePlugin = component.imagePlugins.filterIsInstance<CrossfadePlugin>().firstOrNull()
+  // Scanning the plugin list allocates, and the plugins do not change between compositions.
+  val crossfadePlugin = remember(component) {
+    component.imagePlugins.filterIsInstance<CrossfadePlugin>().firstOrNull()
+  }
+  val requestHolder = remember(request) { StableHolder(request) }
+  val landscapistHolder = remember(landscapist) { StableHolder(landscapist) }
 
   LandscapistImageInternal(
-    request = StableHolder(request),
-    landscapist = StableHolder(landscapist),
+    request = requestHolder,
+    landscapist = landscapistHolder,
     modifier = modifier,
     component = component,
     imageOptions = imageOptions,
@@ -125,7 +131,7 @@ public fun LandscapistImage(
     CrossfadeWithEffect(
       targetState = landscapistState,
       durationMs = crossfadePlugin?.duration ?: 0,
-      contentKey = { it },
+      contentKey = { it.crossfadeKey() },
       enabled = crossfadePlugin != null,
     ) { state ->
       when (state) {
@@ -138,8 +144,8 @@ public fun LandscapistImage(
             executor = { size ->
               LandscapistThumbnail(
                 requestSize = size,
-                recomposeKey = StableHolder(request),
-                landscapist = StableHolder(landscapist),
+                recomposeKey = requestHolder,
+                landscapist = landscapistHolder,
                 imageOptions = imageOptions,
               )
             },
@@ -474,7 +480,7 @@ private fun ImageResult.toImageLoadState(): ImageLoadState = when (this) {
       rawData = rawData,
       diskCachePath = diskCachePath,
     ),
-    dataSource = com.skydoves.landscapist.DataSource.valueOf(dataSource.name),
+    dataSource = dataSource.toLandscapistDataSource(),
   )
   is ImageResult.Failure -> ImageLoadState.Failure(
     data = null,
@@ -492,7 +498,7 @@ private fun ImageLoadState.toImageResult(): ImageResult = when (this) {
     val successData = data as? LandscapistSuccessData
     ImageResult.Success(
       data = successData?.bitmap ?: data ?: Unit,
-      dataSource = com.skydoves.landscapist.core.model.DataSource.valueOf(dataSource.name),
+      dataSource = dataSource.toCoreDataSource(),
       originalWidth = successData?.originalWidth ?: 0,
       originalHeight = successData?.originalHeight ?: 0,
       rawData = successData?.rawData,
@@ -502,6 +508,39 @@ private fun ImageLoadState.toImageResult(): ImageResult = when (this) {
   is ImageLoadState.Failure -> ImageResult.Failure(
     throwable = reason,
   )
+}
+
+/**
+ * What identifies this state to the crossfade.
+ *
+ * Keying on the state itself means `key()` hashes it every composition, and a success state hashes
+ * the encoded image with it. The decoded image is what the crossfade actually distinguishes.
+ */
+private fun LandscapistImageState.crossfadeKey(): Any = when (this) {
+  is LandscapistImageState.Success -> data ?: this
+  else -> this
+}
+
+// Enum.valueOf goes through a name lookup, and these conversions run on every composition. A when
+// is a table switch.
+private fun CoreDataSource.toLandscapistDataSource(): PublicDataSource = when (this) {
+  CoreDataSource.MEMORY -> PublicDataSource.MEMORY
+  CoreDataSource.DISK -> PublicDataSource.DISK
+  CoreDataSource.NETWORK -> PublicDataSource.NETWORK
+  CoreDataSource.LOCAL -> PublicDataSource.LOCAL
+  CoreDataSource.RESOURCE -> PublicDataSource.RESOURCE
+  CoreDataSource.INLINE -> PublicDataSource.INLINE
+  CoreDataSource.UNKNOWN -> PublicDataSource.UNKNOWN
+}
+
+private fun PublicDataSource.toCoreDataSource(): CoreDataSource = when (this) {
+  PublicDataSource.MEMORY -> CoreDataSource.MEMORY
+  PublicDataSource.DISK -> CoreDataSource.DISK
+  PublicDataSource.NETWORK -> CoreDataSource.NETWORK
+  PublicDataSource.LOCAL -> CoreDataSource.LOCAL
+  PublicDataSource.RESOURCE -> CoreDataSource.RESOURCE
+  PublicDataSource.INLINE -> CoreDataSource.INLINE
+  PublicDataSource.UNKNOWN -> CoreDataSource.UNKNOWN
 }
 
 /**
@@ -525,7 +564,7 @@ private data class LandscapistSuccessData(
     if (originalHeight != other.originalHeight) return false
     if (rawData != null) {
       if (other.rawData == null) return false
-      if (!rawData.contentEquals(other.rawData)) return false
+      if (rawData !== other.rawData) return false
     } else if (other.rawData != null) return false
     if (diskCachePath != other.diskCachePath) return false
 
@@ -536,7 +575,7 @@ private data class LandscapistSuccessData(
     var result = bitmap.hashCode()
     result = 31 * result + originalWidth
     result = 31 * result + originalHeight
-    result = 31 * result + (rawData?.contentHashCode() ?: 0)
+    result = 31 * result + (rawData?.size ?: 0)
     result = 31 * result + (diskCachePath?.hashCode() ?: 0)
     return result
   }

--- a/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/ProvideImageSource.skia.kt
+++ b/landscapist-image/src/skiaMain/kotlin/com/skydoves/landscapist/image/ProvideImageSource.skia.kt
@@ -16,6 +16,7 @@
 package com.skydoves.landscapist.image
 
 import androidx.compose.runtime.Composable
+import com.skydoves.landscapist.LocalImageSourceBytes
 import com.skydoves.landscapist.ProvideImageSourceBytes
 
 /**
@@ -28,7 +29,14 @@ public actual fun ProvideImageSource(
   rawData: ByteArray?,
   content: @Composable () -> Unit,
 ) {
-  ProvideImageSourceBytes(bytes = rawData) {
+  // Providing a composition local rebuilds the local map for the subtree, and only the
+  // sub-sampling plugins ever read this one. Nothing to provide and nothing already provided means
+  // nothing to do.
+  if (rawData == null && LocalImageSourceBytes.current == null) {
     content()
+  } else {
+    ProvideImageSourceBytes(bytes = rawData) {
+      content()
+    }
   }
 }

--- a/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/CrossfadeWithEffect.kt
+++ b/landscapist/src/commonMain/kotlin/com/skydoves/landscapist/crossfade/CrossfadeWithEffect.kt
@@ -56,6 +56,17 @@ public fun <T> CrossfadeWithEffect(
   contentKey: (T) -> Any? = { it },
   content: @Composable (T) -> Unit,
 ) {
+  // Nothing is tracked when the animation is off, which is the default: no crossfade plugin means
+  // no fade out to keep alive, and a snapshot state list per image is not free.
+  if (!enabled) {
+    Box(modifier = modifier, propagateMinConstraints = true) {
+      key(contentKey(targetState)) {
+        content(targetState)
+      }
+    }
+    return
+  }
+
   // Seeded with the state this composable entered composition with, for two reasons. Waiting for
   // the effect below to add it leaves the first frame empty, and content that was already resolved
   // when the composable appeared (an image read straight from the memory cache, say) has nothing to
@@ -77,41 +88,27 @@ public fun <T> CrossfadeWithEffect(
   }
 
   Box(modifier = modifier, propagateMinConstraints = true) {
-    if (enabled) {
-      currentlyVisibleItems.forEach { state ->
-        key(contentKey(state)) {
-          val stateKey = contentKey(state)
-          val isTarget = stateKey == contentKey(targetState)
+    currentlyVisibleItems.forEach { state ->
+      key(contentKey(state)) {
+        val stateKey = contentKey(state)
+        val isTarget = stateKey == contentKey(targetState)
 
-          val animationModifier = when {
-            !isTarget -> Modifier.fadeOutWithEffect(key = Unit, durationMs = durationMs)
-            !initialContentReplaced && stateKey == initialContentKey -> Modifier
-            else -> Modifier.fadeInWithEffect(key = stateKey ?: Unit, durationMs = durationMs)
-          }
+        val animationModifier = when {
+          !isTarget -> Modifier.fadeOutWithEffect(key = Unit, durationMs = durationMs)
+          !initialContentReplaced && stateKey == initialContentKey -> Modifier
+          else -> Modifier.fadeInWithEffect(key = stateKey ?: Unit, durationMs = durationMs)
+        }
 
-          if (!isTarget) {
-            LaunchedEffect(Unit) {
-              delay(durationMs.toLong())
-              currentlyVisibleItems.remove(state)
-            }
-          }
-
-          Box(modifier = animationModifier, propagateMinConstraints = true) {
-            content(state)
+        if (!isTarget) {
+          LaunchedEffect(Unit) {
+            delay(durationMs.toLong())
+            currentlyVisibleItems.remove(state)
           }
         }
-      }
-    } else {
-      if (currentlyVisibleItems.size > 1 || currentlyVisibleItems.firstOrNull() != targetState) {
-        currentlyVisibleItems.retainAll { contentKey(it) == contentKey(targetState) }
-        if (currentlyVisibleItems.isEmpty()) {
-          currentlyVisibleItems.add(targetState)
-        }
-      }
 
-      // Render the content directly without any animation modifiers.
-      key(contentKey(targetState)) {
-        content(targetState)
+        Box(modifier = animationModifier, propagateMinConstraints = true) {
+          content(state)
+        }
       }
     }
   }


### PR DESCRIPTION
Continues #986. Adds a Compose half to the benchmark, so the UI layer is measured too, and fixes what both halves found. Reproduce everything with `./gradlew :benchmark-engine:run`.

Before is `main`, after is this branch, and Coil is 3.6.2. The fetcher hands both loaders an already decoded image sized to the request, so the engine numbers time the loader rather than the decoder.

### Core

| | before | after | Coil |
|---|---|---|---|
| memory cache hit p50 | 792 ns | 875 ns | 750 ns |
| cold load p50 | 25.1 us | **22.9 us** | 15.4 us |
| allocation per hit | 1.1 KiB | **988 B** | 1.6 KiB |
| 32 concurrent, same image | 1 fetch | **1 fetch** | 32 fetches |
| 6 loads at 358 to 361 px | 4 fetches | **1 fetch** | 3 fetches |
| decode 4000x3000 to 400x300 | 322 ms | **136 ms** | 49 ms |
| allocation for that decode | 345 MiB | **1.6 MiB** | |

The memory cache keyed strictly on the target size, so a grid whose columns do not divide evenly made a separate entry and a separate decode for 359, 360 and 361 wide. An entry already at least as large is now reused, with a pixel of tolerance.

The desktop decoder read every pixel and then shrank the result with `SCALE_SMOOTH`. It asks ImageIO to skip pixels while reading now, so a 4000x3000 photo never materialises at full size to make a thumbnail. That is where the 345 MiB went.

Also: the decode scheduler took a monitor on every decode to re-read a field that stops changing after the first image, and keyed its active map on `model.hashCode()`, so two different URLs at one size could alias. `ImageRequest.Builder` allocated a map and a list per request and copied both in `build()`, for requests that carry neither.

The memory hit row moved by less than the run to run noise at that scale; the peek in the same run swings between 125 and 209 ns.

### Compose

Rendered offscreen through `ImageComposeScene`, so it composes, lays out and rasterizes with no display. Both caches are warm, which is the state a list is in once scrolled.

| | before | after | Coil |
|---|---|---|---|
| first frame, 20 cached images | 16.40 ms | **16.11 ms** | 15.03 ms |
| allocation above an empty scene | 358 KiB | **300 KiB** | 97 KiB |

The crossfade wrapper kept a snapshot state list per image even with no crossfade plugin, which is the default. The image source composition local rebuilt the local map for every image although only the sub-sampling plugins read it. Converting between the state types called `Enum.valueOf`, a name lookup, twice per composition per image, and the crossfade keyed on the whole state, so `key()` hashed the encoded image every composition. Scanning the plugin list and rewrapping the loader ran on every composition.

### What is still behind, honestly

Coil is faster on a cold load and on decode, and allocates far less in Compose. The Compose gap is structural rather than incidental: with an empty `success` slot, before anything is drawn, the framework costs **198 KiB for 20 images against Coil's 97 KiB for the whole thing**. That is node count and plugin dispatch, and it wants a redesign rather than another peephole fix. The decode gap is ImageIO against Skia and only affects desktop; on Android both libraries use `BitmapFactory`.

Where we are ahead: concurrent loads of one image, near identical sizes, and allocation per memory hit.

### Verification

312 desktop tests pass. `assemble`, `spotlessCheck`, `apiCheck`, `stabilityCheck` and `testDebugUnitTest` pass. Every changed module compiles for android, desktop, iosArm64, macosArm64 and wasmJs. The api and stability dumps are unchanged.

`ImageResult.Success` and `LandscapistImageState.Success` keep their content based equality; an earlier attempt to make it cheap broke `ImageResultTest`, and the cost turned out to be the crossfade key rather than the equality itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved desktop image decoding by reducing unnecessary full-size processing and scaling.
  * Improved memory-cache reuse while ensuring cached images meet requested dimensions.
  * Reduced composition overhead and improved crossfade rendering efficiency.
  * Optimized image-source handling when no cached source is available.
  * Improved scheduler startup performance.

* **Benchmarking**
  * Added comparisons for image decoding, rendering, timing, and memory allocation across supported image-loading approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->