### PR TITLE
Stop a cookie a strict parser refuses from failing the image

### DIFF
--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/network/KtorImageFetcher.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/network/KtorImageFetcher.kt
@@ -22,7 +22,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.HttpTimeout
-import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.statement.bodyAsBytes
@@ -141,7 +140,10 @@ internal fun HttpClientConfig<*>.configureForImageLoading(networkConfig: Network
   // producing an endless loop that only ends when the send-count limit is hit. Browsers avoid this
   // because they retain cookies automatically.
   // See https://github.com/skydoves/landscapist/issues/859
-  install(HttpCookies)
+  //
+  // Not ktor's HttpCookies, which cannot read a `Set-Cookie` that any real site might send without
+  // risking an exception that fails the download. See [RedirectCookies].
+  install(RedirectCookies)
 
   install(HttpSend) {
     // maxSendCount is the total number of times a request may be dispatched (the original request

--- a/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/network/RedirectCookies.kt
+++ b/landscapist-core/src/commonMain/kotlin/com/skydoves/landscapist/core/network/RedirectCookies.kt
@@ -1,0 +1,139 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.skydoves.landscapist.core.network
+
+import io.ktor.client.plugins.api.createClientPlugin
+import io.ktor.client.request.HttpSendPipeline
+import io.ktor.client.statement.HttpReceivePipeline
+import io.ktor.http.HttpHeaders
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
+
+/**
+ * Carries cookies from one hop of a redirect chain to the next.
+ *
+ * Some CDNs set a cookie on the first response and redirect to a target that requires it. Without
+ * one, the target keeps redirecting until the send limit is hit. See
+ * https://github.com/skydoves/landscapist/issues/859.
+ *
+ * Ktor's own `HttpCookies` does this, and cannot be used for it: it parses every attribute of every
+ * `Set-Cookie` header it sees, and `max-age` is parsed with `toLong()` rather than the `runCatching`
+ * that guards `expires` beside it. A server that sends `max-age=7.0`, which unsplash.com does,
+ * throws `NumberFormatException` out of the response pipeline and fails the request. The image has
+ * nothing to do with the cookie, and the download dies anyway.
+ *
+ * So only the part that is needed is read here: the name, the value, and the domain to send it back
+ * to. Every other attribute is ignored rather than parsed, which is what makes this unable to fail
+ * on one. Cookies live in memory for the life of the client and are not persisted.
+ */
+internal val RedirectCookies = createClientPlugin("RedirectCookies") {
+  val jar = CookieJar()
+  // The send and receive pipelines rather than onRequest and onResponse, because a redirect hop is
+  // dispatched through these two and never through the request pipeline. Hooking the wrong pair
+  // reads only the final response, which is the one hop whose cookie nothing still needs.
+  client.sendPipeline.intercept(HttpSendPipeline.State) {
+    val held = jar.headerFor(context.url.host) ?: return@intercept
+    val existing = context.headers[HttpHeaders.Cookie]
+    // Set rather than append, and the caller's own header first: a caller who sent a cookie keeps
+    // it, and a second hop does not send the header twice.
+    context.headers[HttpHeaders.Cookie] =
+      if (existing.isNullOrEmpty()) held else "$existing; $held"
+  }
+  client.receivePipeline.intercept(HttpReceivePipeline.State) { response ->
+    val set = response.headers.getAll(HttpHeaders.SetCookie)
+    if (!set.isNullOrEmpty()) jar.record(response.call.request.url.host, set)
+  }
+}
+
+/**
+ * The cookies one client has been handed, by the domain they are to be sent back to.
+ *
+ * Deliberately small: no paths, no expiry, no secure flag. This exists to get a redirect hop the
+ * cookie the hop before it was given, which lasts milliseconds, not to be a browser's cookie store.
+ */
+internal class CookieJar {
+
+  private val lock = SynchronizedObject()
+  private val byDomain = linkedMapOf<String, MutableMap<String, String>>()
+
+  /** Reads the `name=value` and the domain out of each header, ignoring every other attribute. */
+  fun record(host: String, headers: List<String>): Unit = synchronized(lock) {
+    for (header in headers) {
+      val parts = header.split(';')
+      val pair = parts.firstOrNull()?.trim() ?: continue
+      val separator = pair.indexOf('=')
+      if (separator <= 0) continue
+      val name = pair.substring(0, separator).trim()
+      val value = pair.substring(separator + 1).trim()
+      if (name.isEmpty()) continue
+      val domain = parts.asSequence()
+        .drop(1)
+        .map { it.trim() }
+        .firstOrNull { it.startsWith(DOMAIN_ATTRIBUTE, ignoreCase = true) }
+        ?.substring(DOMAIN_ATTRIBUTE.length)
+        ?.trim()
+        ?.removePrefix(".")
+        ?.lowercase()
+        ?.takeIf { it.isNotEmpty() && host.matchesDomain(it) }
+        ?: host.lowercase()
+      val cookies = byDomain.getOrPut(domain) { linkedMapOf() }
+      // An empty value is how a server clears a cookie, and the attribute that usually carries the
+      // clearing is one of the ones not read here.
+      if (value.isEmpty()) cookies.remove(name) else cookies[name] = value
+      if (cookies.isEmpty()) byDomain.remove(domain)
+      evictIfNeeded()
+    }
+  }
+
+  /** The `Cookie` header value for [host], or null when there is nothing to send it. */
+  fun headerFor(host: String): String? = synchronized(lock) {
+    val lowered = host.lowercase()
+    var joined: StringBuilder? = null
+    for ((domain, cookies) in byDomain) {
+      if (!lowered.matchesDomain(domain)) continue
+      for ((name, value) in cookies) {
+        val target = joined ?: StringBuilder().also { joined = it }
+        if (target.isNotEmpty()) target.append("; ")
+        target.append(name).append('=').append(value)
+      }
+    }
+    joined?.toString()
+  }
+
+  /**
+   * Whether a cookie held for [domain] belongs to this host.
+   *
+   * The host itself, or a subdomain of it. A cookie is never sent anywhere else, so a redirect that
+   * leaves the site leaves the cookie behind.
+   */
+  private fun String.matchesDomain(domain: String): Boolean {
+    val lowered = lowercase()
+    return lowered == domain || lowered.endsWith(".$domain")
+  }
+
+  /** Keeps a long lived client from accumulating a domain per host it has ever been sent to. */
+  private fun evictIfNeeded() {
+    while (byDomain.size > MAX_DOMAINS) {
+      val oldest = byDomain.keys.firstOrNull() ?: return
+      byDomain.remove(oldest)
+    }
+  }
+
+  private companion object {
+    const val DOMAIN_ATTRIBUTE = "domain="
+    const val MAX_DOMAINS = 64
+  }
+}

--- a/landscapist-core/src/commonTest/kotlin/com/skydoves/landscapist/core/network/KtorImageFetcherTest.kt
+++ b/landscapist-core/src/commonTest/kotlin/com/skydoves/landscapist/core/network/KtorImageFetcherTest.kt
@@ -29,6 +29,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class KtorImageFetcherTest {
@@ -120,6 +122,98 @@ class KtorImageFetcherTest {
     assertTrue(
       result.throwable is SendCountExceedException,
       "expected SendCountExceedException but was ${result.throwable}",
+    )
+  }
+
+  /**
+   * A `Set-Cookie` a strict parser refuses must not take the image down with it.
+   *
+   * unsplash.com sends `max-age=7.0` on one of its cookies. Ktor's own cookie plugin parses that
+   * attribute with `toLong()`, where the `expires` beside it is wrapped in `runCatching`, so the
+   * NumberFormatException leaves the response pipeline and fails the request. Every image on
+   * unsplash stopped loading because of a cookie no image needs.
+   */
+  @Test
+  fun aCookieAttributeNoParserAcceptsDoesNotFailTheDownload() = runTest {
+    val imageBytes = byteArrayOf(0x9, 0x8, 0x7)
+    val engine = MockEngine {
+      respond(
+        content = imageBytes,
+        status = HttpStatusCode.OK,
+        headers = headersOf(
+          HttpHeaders.ContentType to listOf("image/png"),
+          HttpHeaders.SetCookie to listOf(
+            "arpa_context=%7B%7D; path=/; max-age=7.0; expires=not a date; HttpOnly; secure",
+          ),
+        ),
+      )
+    }
+
+    val result = fetchImage(engine, NetworkConfig(), "https://example.com/image.png")
+
+    assertTrue(result is FetchResult.Success, "expected success but was $result")
+    assertContentEquals(imageBytes, result.data)
+  }
+
+  @Test
+  fun aCookieIsNotSentToAnotherSite() = runTest {
+    val seen = mutableListOf<String?>()
+    val engine = MockEngine { request ->
+      seen += request.headers[HttpHeaders.Cookie]
+      if (request.url.host == "first.example.com") {
+        respond(
+          content = "",
+          status = HttpStatusCode.Found,
+          headers = headersOf(
+            HttpHeaders.Location to listOf("https://unrelated.test/image.png"),
+            HttpHeaders.SetCookie to listOf("session=granted; Path=/"),
+          ),
+        )
+      } else {
+        respond(
+          content = byteArrayOf(0x1),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "image/png"),
+        )
+      }
+    }
+
+    fetchImage(engine, NetworkConfig(), "https://first.example.com/image.png")
+
+    assertEquals(2, seen.size, "the redirect was not followed, saw $seen")
+    assertNull(seen[1], "a cookie set by one site was sent to another, saw $seen")
+  }
+
+  @Test
+  fun aDomainCookieReachesTheSubdomainItWasSetFor() = runTest {
+    // What issue 859 is: the cookie is set by the site and needed by its own CDN host.
+    val seen = mutableListOf<String?>()
+    val engine = MockEngine { request ->
+      seen += request.headers[HttpHeaders.Cookie]
+      if (request.url.host == "example.com") {
+        respond(
+          content = "",
+          status = HttpStatusCode.Found,
+          headers = headersOf(
+            HttpHeaders.Location to listOf("https://cdn.example.com/image.png"),
+            HttpHeaders.SetCookie to listOf("session=granted; Domain=.example.com; Path=/"),
+          ),
+        )
+      } else {
+        respond(
+          content = byteArrayOf(0x1),
+          status = HttpStatusCode.OK,
+          headers = headersOf(HttpHeaders.ContentType, "image/png"),
+        )
+      }
+    }
+
+    fetchImage(engine, NetworkConfig(), "https://example.com/image.png")
+
+    assertEquals(2, seen.size, "the redirect was not followed, saw $seen")
+    assertTrue(
+      seen[1]?.contains("session=granted") == true,
+      "the cookie did not reach the subdomain it was set for, saw $seen",
     )
   }
 }


### PR DESCRIPTION
Every image on unsplash.com fails to load. The demo app in this repository shows it: the posters tab is empty, and it is empty on `main` too.

## What happens

The response carries this header:

```
set-cookie: arpa_context=%7B%7D; path=/; max-age=7.0; expires=Thu, 01 Jan 1970 00:00:07 GMT; HttpOnly; secure
```

Ktor's `HttpCookies` parses every attribute of every `Set-Cookie` it sees. In `Cookie.kt`:

```kotlin
expires = runCatching { loweredMap["expires"]?.fromCookieToGmtDate() }.getOrNull(),
maxAge = loweredMap["max-age"]?.toIntClamping(),
...
private fun String.toIntClamping(): Int = toLong().coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
```

`expires` is guarded, `max-age` is not. `"7.0".toLong()` throws, the `NumberFormatException` leaves the response pipeline, and the request fails. The image has nothing to do with the cookie and the download dies anyway. Any site sending a non-integer `max-age` breaks the same way.

## What this changes

`HttpCookies` is installed here for #859, where a CDN sets a cookie on one response and redirects to a target that needs it. That is the only reason it is installed, so that is all the replacement does: read the name, the value and the domain out of each `Set-Cookie`, and ignore every other attribute rather than parse it. Ignoring is what makes it unable to fail on one.

It hooks the send and receive pipelines rather than `onRequest` and `onResponse`. A redirect hop is dispatched through those two and never through the request pipeline, so the other pair sees only the final response, which is the one hop whose cookie nothing still needs.

Cookies are held per domain for the life of the client, sent only to the host that set them or to a subdomain of a `Domain` attribute, and never persisted. There is no expiry: this carries a cookie across a redirect that lasts milliseconds, it is not a browser's cookie store.

## Verified

On an emulator, the unsplash URL goes from `NumberFormatException` to a 378x504 bitmap, and the demo app renders its posters, palette and all.

Tests: the existing #859 regression test still passes, and three new ones cover the malformed attribute, a cookie not leaking to another site, and a `Domain` cookie reaching the subdomain it was set for. Reverting to `HttpCookies` fails the first of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image loading across redirects by preserving relevant cookies between requests.
  - Malformed cookie attributes no longer interrupt image downloads.
  - Cookies are now restricted to the appropriate domains and subdomains, preventing them from being sent to unrelated sites.
  - Cookie updates and removals are handled more reliably during image requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->