### PR TITLE
Add a wasm web playground under the documentation site

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -66,6 +66,17 @@ jobs:
               assemble -x :benchmark-landscapist:pixel6api31Setup -x :benchmark-landscapist:pixel6api31NonMinifiedReleaseAndroidTest -x :benchmark-landscapist:collectNonMinifiedReleaseBaselineProfile \
               -x prepareReleaseArtProfile
 
+      # Not part of `assemble`, deliberately, so the Android build does not pay for webpack. It is
+      # named here because the publish-docs workflow deploys whatever this produces, and without a
+      # pull request check a broken demo would first show up as a broken page on the site.
+      # --no-configure-on-demand for the reason spelled out in publish-docs.yml: the wasm yarn
+      # lockfile is resolved from every configured project, so a narrow build resolves a narrower
+      # lock than the one committed.
+      - name: Build the web demo
+        run: |
+          ./gradlew --scan --stacktrace --no-configure-on-demand \
+              :demo-web:wasmJsBrowserDistribution
+
       # desktopTest covers landscapist-core, landscapist-image, the crossfade and the SVG decoder,
       # none of which have an Android unit test. Without it those run nowhere.
       - name: Run unit tests

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  
+
 jobs:
   deploy:
     runs-on: macos-latest
@@ -15,12 +15,44 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+
+      # The wasm playground is built into the site rather than published to gh-pages on its own.
+      # `mkdocs gh-deploy --force` replaces that branch with a commit whose tree is exactly `site/`,
+      # so anything a second job pushed there would be gone on the next push to main.
+      - name: Set up JDK
+        uses: actions/setup-java@v6.0.1
+        with:
+          distribution: 'zulu'
+          java-version: 21
+      - name: Cache Gradle and wrapper
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build the web demo
+        run: |
+          chmod +x ./gradlew
+          # --no-configure-on-demand because gradle.properties turns it on, and with it a build
+          # that names only this task configures only this module. The wasm yarn lockfile is
+          # resolved from every configured project's package.json, so a narrow build resolves a
+          # narrower lock than the committed one and kotlinWasmStoreYarnLock fails on the
+          # difference. Configuring everything makes the resolved lock the committed one.
+          ./gradlew :demo-web:wasmJsBrowserDistribution --no-configure-on-demand --stacktrace
+      - name: Copy the web demo into the docs
+        run: |
+          mkdir -p docs/demo
+          cp -R demo-web/build/dist/wasmJs/productionExecutable/. docs/demo/
+
+      - run: echo "cache_id=$(date -u '+%V')" >> $GITHUB_ENV
       - uses: actions/cache@v6
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material 
+      - run: pip install mkdocs-material
       - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ google-services.json
 
 # Temporary API docs
 docs/api
+
+# The wasm demo, built into the docs site by .github/workflows/publish-docs.yml
+docs/demo
 .hotswan/
 
 # Agent worktrees

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@
 🌻 <a href="https://skydoves.github.io/landscapist" target="_blank"> Landscapist</a> is a highly optimized, pluggable Jetpack Compose and Kotlin Multiplatform image loading solution that fetches and displays network images, and compatibles with <a href="https://github.com/bumptech/glide" target="_blank"> Glide</a>, <a href="https://github.com/coil-kt/coil" target="_blank"> Coil</a>, and <a href="https://github.com/facebook/fresco" target="_blank"> Fresco.</a> This library supports tracing image loading states, composing custom implementations, and some valuable animations, such as crossfades, blur transformation, and circular reveals. You can also configure and attach image-loading behaviors easily and fast with image plugins. <br><br> <a align="center" href="https://skydoves.github.io/landscapist" target="_blank">See official documentation for Landscapist</a>
 </p>
 
+## Try it in a browser
+
+The [playground](https://skydoves.github.io/landscapist/demo/) runs `landscapist-image` compiled to
+WebAssembly. Every image size, content scale and plugin combination is a switch, and the readout
+next to the image is what the loader reported.
+
 ## Who's using Landscapist?
 👉 [Check out who's using Landscapist](https://skydoves.github.io/landscapist/#whos-using-landscapist).
 

--- a/demo-web/build.gradle.kts
+++ b/demo-web/build.gradle.kts
@@ -1,0 +1,70 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  alias(libs.plugins.kotlin.multiplatform)
+  alias(libs.plugins.jetbrains.compose)
+  alias(libs.plugins.compose.compiler)
+  id("landscapist.spotless")
+}
+
+// The web playground, published to https://skydoves.github.io/landscapist/demo/ by
+// .github/workflows/publish-docs.yml. Not published to Maven, so none of the library convention
+// plugins apply here: they all bring com.android.library, maven publishing, explicitApi() and the
+// API validator, and an app wants none of those.
+kotlin {
+  wasmJs {
+    browser {
+      // rootProject.name is LandscapistDemo, so without this the bundle would be called
+      // LandscapistDemo-demo-web.js.
+      commonWebpackConfig {
+        outputFileName = "demo.js"
+      }
+    }
+    binaries.executable()
+  }
+
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(project(":landscapist"))
+        implementation(project(":landscapist-core"))
+        implementation(project(":landscapist-image"))
+        implementation(project(":landscapist-animation"))
+        implementation(project(":landscapist-placeholder"))
+        implementation(project(":landscapist-zoomable"))
+
+        implementation(compose.runtime)
+        implementation(compose.foundation)
+        implementation(compose.material)
+        implementation(compose.ui)
+
+        // Real Coil, not the landscapist wrapper: the comparison column is meant to be the other
+        // library rather than this library's binding to it.
+        implementation(libs.coil3)
+        implementation(libs.coil3.compose)
+        implementation(libs.coil3.network.ktor3)
+      }
+    }
+
+    wasmJsMain {
+      dependencies {
+        // Coil's Ktor fetcher picks its engine off the classpath. landscapist-core has its own
+        // copy but declares it as implementation, so it does not reach here.
+        implementation(libs.ktor.engine.js)
+      }
+    }
+  }
+}

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/DemoApp.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/DemoApp.kt
@@ -1,0 +1,80 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.ImageLoader
+import coil3.compose.setSingletonImageLoaderFactory
+import coil3.network.ktor3.KtorNetworkFetcherFactory
+import com.github.skydoves.landscapistdemo.web.theme.LandscapistDemoTheme
+
+/**
+ * The whole demo. One screen, deliberately: the point is the controls, not navigation.
+ */
+@Composable
+internal fun DemoApp() {
+  // Coil has no network fetcher of its own on wasm, so the comparison column would report Error on
+  // every url without this. Landscapist needs no equivalent: landscapist-core carries the Ktor js
+  // engine for this target itself.
+  setSingletonImageLoaderFactory { context ->
+    ImageLoader.Builder(context)
+      .components { add(KtorNetworkFetcherFactory()) }
+      .build()
+  }
+
+  LandscapistDemoTheme {
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
+      Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+      ) {
+        // Capped, because the browser window can be far wider than any phone and a playground
+        // stretched across a desktop monitor puts every control a mouse journey apart.
+        Column(modifier = Modifier.widthIn(max = 560.dp).fillMaxWidth()) {
+          DemoHeader()
+          PlaygroundScreen()
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun DemoHeader() {
+  Text(
+    text = "Landscapist playground",
+    style = MaterialTheme.typography.h1,
+    fontSize = 22.sp,
+    modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 20.dp),
+  )
+  HintText(
+    "Every control below drives one real load through landscapist-image, compiled to " +
+      "WebAssembly and running in this tab. The readout is what the loader reported.",
+  )
+}

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundComparison.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundComparison.kt
@@ -1,0 +1,132 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.image.LandscapistImage
+import com.skydoves.landscapist.image.LandscapistImageState
+
+/**
+ * The same url, size and content scale through Landscapist and through Coil. Neither side has a
+ * plugin or placeholder, so what differs is the loader.
+ */
+@Composable
+internal fun PlaygroundComparison(url: String, contentScale: ContentScale) {
+  var landscapistState by remember { mutableStateOf("None") }
+  var coilState by remember { mutableStateOf<AsyncImagePainter.State?>(null) }
+
+  val imageOptions = remember(contentScale) { ImageOptions(contentScale = contentScale) }
+  val boxModifier = Modifier
+    .fillMaxWidth()
+    .height(150.dp)
+    .border(width = 1.dp, color = Color(0xFF9E9E9E))
+
+  SectionHeader("LandscapistImage vs Coil AsyncImage")
+  HintText("The same url in the same 150dp box, with no plugins on either side.")
+
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 12.dp),
+    horizontalArrangement = Arrangement.spacedBy(8.dp),
+  ) {
+    ComparisonColumn(
+      modifier = Modifier.weight(1f),
+      title = "Landscapist",
+      state = landscapistState,
+    ) {
+      LandscapistImage(
+        imageModel = { url },
+        modifier = boxModifier,
+        imageOptions = imageOptions,
+        onImageStateChanged = { landscapistState = it.label() },
+      )
+    }
+
+    ComparisonColumn(
+      modifier = Modifier.weight(1f),
+      title = "Coil",
+      state = coilState.label(),
+    ) {
+      AsyncImage(
+        model = url,
+        contentDescription = null,
+        modifier = boxModifier,
+        onState = { coilState = it },
+        contentScale = contentScale,
+      )
+    }
+  }
+}
+
+@Composable
+private fun ComparisonColumn(
+  modifier: Modifier,
+  title: String,
+  state: String,
+  image: @Composable () -> Unit,
+) {
+  Column(modifier = modifier) {
+    Text(
+      text = title,
+      style = MaterialTheme.typography.body1,
+      fontSize = 12.sp,
+      fontWeight = FontWeight.Bold,
+    )
+    image()
+    Text(
+      text = state,
+      style = MaterialTheme.typography.body2,
+      fontSize = 11.sp,
+    )
+  }
+}
+
+private fun LandscapistImageState.label(): String = when (this) {
+  is LandscapistImageState.None -> "None"
+  is LandscapistImageState.Loading -> "Loading"
+  is LandscapistImageState.Success -> "Success (${dataSource.name})"
+  is LandscapistImageState.Failure -> "Failure"
+}
+
+private fun AsyncImagePainter.State?.label(): String = when (this) {
+  is AsyncImagePainter.State.Loading -> "Loading"
+  is AsyncImagePainter.State.Success -> "Success (${result.dataSource.name})"
+  is AsyncImagePainter.State.Error -> "Error"
+  else -> "Empty"
+}

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundControls.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundControls.kt
@@ -1,0 +1,206 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Card
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.github.skydoves.landscapistdemo.web.theme.purple200
+
+/** A heading that separates one group of controls from the next. */
+@Composable
+internal fun SectionHeader(title: String) {
+  Text(
+    text = title,
+    style = MaterialTheme.typography.h2,
+    fontSize = 15.sp,
+    modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 18.dp, bottom = 4.dp),
+  )
+}
+
+/** Small explanatory text under a heading or a control. */
+@Composable
+internal fun HintText(text: String) {
+  Text(
+    text = text,
+    style = MaterialTheme.typography.body2,
+    fontSize = 11.sp,
+    modifier = Modifier.padding(start = 12.dp, end = 12.dp, bottom = 4.dp),
+  )
+}
+
+/**
+ * A horizontally scrolling row of buttons, one of which is selected. Scrolling rather than
+ * wrapping, so it stays one line tall on a narrow window.
+ */
+@Composable
+internal fun <T> ChoiceRow(
+  options: List<T>,
+  selected: T,
+  label: (T) -> String,
+  onSelected: (T) -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .horizontalScroll(rememberScrollState())
+      .padding(horizontal = 12.dp, vertical = 2.dp),
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    options.forEach { option ->
+      val isSelected = option == selected
+      Button(
+        onClick = { onSelected(option) },
+        elevation = null,
+        colors = ButtonDefaults.buttonColors(
+          backgroundColor = if (isSelected) purple200 else Color(0xFF9E9E9E),
+          contentColor = Color.White,
+        ),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+      ) {
+        Text(
+          text = label(option),
+          fontSize = 12.sp,
+          fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+        )
+      }
+    }
+  }
+}
+
+/** A horizontally scrolling row of buttons that each run an action. */
+@Composable
+internal fun ActionRow(actions: List<Pair<String, () -> Unit>>) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .horizontalScroll(rememberScrollState())
+      .padding(horizontal = 12.dp, vertical = 2.dp),
+    horizontalArrangement = Arrangement.spacedBy(6.dp),
+  ) {
+    actions.forEach { (text, action) ->
+      Button(
+        onClick = action,
+        elevation = null,
+        colors = ButtonDefaults.buttonColors(
+          backgroundColor = purple200,
+          contentColor = Color.White,
+        ),
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+      ) {
+        Text(text = text, fontSize = 12.sp)
+      }
+    }
+  }
+}
+
+/** A labelled switch, one per plugin. */
+@Composable
+internal fun ToggleRow(
+  label: String,
+  checked: Boolean,
+  onCheckedChange: (Boolean) -> Unit,
+) {
+  Row(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(start = 12.dp, end = 12.dp),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.body1,
+      fontSize = 13.sp,
+      modifier = Modifier.weight(1f),
+    )
+    Switch(
+      checked = checked,
+      onCheckedChange = onCheckedChange,
+      colors = SwitchDefaults.colors(checkedThumbColor = purple200),
+    )
+  }
+}
+
+/** The state, size, data source and timing of the current load. */
+@Composable
+internal fun ReadoutPanel(readout: ImageReadout, url: String) {
+  Card(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(horizontal = 12.dp, vertical = 6.dp),
+    backgroundColor = Color(0x22808080),
+    elevation = 0.dp,
+  ) {
+    Column(modifier = Modifier.padding(10.dp)) {
+      ReadoutLine("state", readout.state)
+      ReadoutLine(
+        label = "decoded size",
+        value = if (readout.width > 0 || readout.height > 0) {
+          "${readout.width} x ${readout.height}"
+        } else {
+          "-"
+        },
+      )
+      ReadoutLine("data source", readout.dataSource)
+      ReadoutLine(
+        label = "elapsed",
+        value = if (readout.elapsedMs >= 0) "${readout.elapsedMs} ms" else "-",
+      )
+      if (readout.failure != null) {
+        ReadoutLine("failure", readout.failure)
+      }
+      ReadoutLine("url", url)
+    }
+  }
+}
+
+@Composable
+private fun ReadoutLine(label: String, value: String) {
+  Row(modifier = Modifier.fillMaxWidth()) {
+    Text(
+      text = label,
+      style = MaterialTheme.typography.body2,
+      fontSize = 12.sp,
+      modifier = Modifier.weight(0.35f),
+    )
+    Text(
+      text = value,
+      style = MaterialTheme.typography.body1,
+      fontSize = 12.sp,
+      fontWeight = FontWeight.Bold,
+      modifier = Modifier.weight(0.65f),
+    )
+  }
+}

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundOptions.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundOptions.kt
@@ -1,0 +1,114 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.layout.ContentScale
+
+/**
+ * Three of them, so a cold cache is one click away: switching to a url never loaded is the only way
+ * to watch a network load happen again.
+ *
+ * They have to be served with `Access-Control-Allow-Origin`, because the browser reads the bytes
+ * through `fetch` rather than handing the url to an `<img>` tag. Unsplash sends it.
+ */
+internal val playgroundImageUrls: List<String> = listOf(
+  "https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=1200",
+  "https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=1200",
+  "https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=1200",
+)
+
+/** A url that resolves but cannot be decoded as an image, so the failure path is reachable. */
+internal const val FAILING_IMAGE_URL: String =
+  "https://images.unsplash.com/this-photo-does-not-exist-404.jpg"
+
+/** The sample hash from the BlurHashPlugin documentation. */
+internal const val SAMPLE_BLUR_HASH: String = "LEHV6nWB2yk8pyo0adR*.7kCMdnj"
+
+/** The sample hash from the ThumbHashPlugin documentation. */
+internal const val SAMPLE_THUMB_HASH: String = "1QcSHQRnh493V4dIh4eXh1h4kJUI"
+
+/** How the image composable is sized, which is what decides the constraints it decodes against. */
+internal enum class SizeMode(val label: String) {
+  Fixed("Fixed 200dp"),
+  FillWidth("Fill width"),
+  AspectRatio("16:9"),
+  Unsized("No size"),
+}
+
+/** The [ContentScale] applied through `ImageOptions`. */
+internal enum class ScaleMode(val label: String, val contentScale: ContentScale) {
+  Crop("Crop", ContentScale.Crop),
+  Fit("Fit", ContentScale.Fit),
+  Inside("Inside", ContentScale.Inside),
+  None("None", ContentScale.None),
+  FillBounds("FillBounds", ContentScale.FillBounds),
+}
+
+/**
+ * Where the next load is meant to come from. None of these force a data source: they arrange the
+ * conditions, and the readout reports what actually happened.
+ *
+ * The Android playground has a fourth, Disk. There is no disk cache on wasm, so it is not here.
+ */
+internal enum class LoadSource(val label: String, val hint: String) {
+  Network(
+    label = "Network",
+    hint = "Both caches are disabled on the request, so every reload goes out to the network.",
+  ),
+  Memory(
+    label = "Memory",
+    hint = "Memory cache on. The first load fills it; reload to see the hit.",
+  ),
+  Failure(
+    label = "Failure",
+    hint = "Loads a url that is not an image, so the failure state and failure plugins show.",
+  ),
+}
+
+/**
+ * Which plugins are attached to the image.
+ *
+ * Immutable and in one state so it can key the component: `rememberImageComponent` remembers
+ * without keys and would otherwise keep the plugin list built on the first composition.
+ *
+ * Two of the Android playground's toggles are missing. `PalettePlugin` needs kmpalette, which
+ * publishes no wasmJs variant, and `BlurTransformationPlugin` is an Android library built around a
+ * native RenderScript blur.
+ */
+@Immutable
+internal data class PluginToggles(
+  val crossfade: Boolean = true,
+  val circularReveal: Boolean = false,
+  val shimmer: Boolean = false,
+  val zoomable: Boolean = false,
+  val blurHash: Boolean = false,
+  val thumbHash: Boolean = false,
+  val thumbnail: Boolean = false,
+  val placeholder: Boolean = false,
+  val progressive: Boolean = false,
+)
+
+/** What the readout panel shows about the current load. */
+@Immutable
+internal data class ImageReadout(
+  val state: String = "None",
+  val width: Int = 0,
+  val height: Int = 0,
+  val dataSource: String = "-",
+  val elapsedMs: Long = -1L,
+  val failure: String? = null,
+)

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundScreen.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/PlaygroundScreen.kt
@@ -1,0 +1,367 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.skydoves.landscapist.ImageOptions
+import com.skydoves.landscapist.animation.circular.CircularRevealPlugin
+import com.skydoves.landscapist.components.rememberImageComponent
+import com.skydoves.landscapist.core.ImageRequest
+import com.skydoves.landscapist.core.model.CachePolicy
+import com.skydoves.landscapist.crossfade.CrossfadePlugin
+import com.skydoves.landscapist.image.LandscapistImage
+import com.skydoves.landscapist.image.LandscapistImageState
+import com.skydoves.landscapist.image.getLandscapist
+import com.skydoves.landscapist.placeholder.blurhash.BlurHashPlugin
+import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
+import com.skydoves.landscapist.placeholder.progressive.ProgressiveLoadingPlugin
+import com.skydoves.landscapist.placeholder.shimmer.Shimmer
+import com.skydoves.landscapist.placeholder.shimmer.ShimmerPlugin
+import com.skydoves.landscapist.placeholder.thumbhash.ThumbHashPlugin
+import com.skydoves.landscapist.placeholder.thumbnail.ThumbnailPlugin
+import com.skydoves.landscapist.zoomable.ZoomableConfig
+import com.skydoves.landscapist.zoomable.ZoomablePlugin
+import com.skydoves.landscapist.zoomable.rememberZoomableState
+import kotlinx.coroutines.launch
+import kotlin.time.TimeSource
+
+/**
+ * Exercises every plugin, sizing mode and loading source that the wasm target supports, against a
+ * real network image, with a readout of what the loader reported. Driven only by public API.
+ *
+ * A port of the Android sample's playground, not a fork of it: the two are meant to read alike but
+ * they are not kept in step, because the browser supports a smaller set of plugins.
+ */
+@Composable
+internal fun PlaygroundScreen() {
+  val landscapist = getLandscapist()
+  val scope = rememberCoroutineScope()
+
+  var toggles by remember { mutableStateOf(PluginToggles()) }
+  var sizeMode by remember { mutableStateOf(SizeMode.Fixed) }
+  var scaleMode by remember { mutableStateOf(ScaleMode.Crop) }
+  var source by remember { mutableStateOf(LoadSource.Memory) }
+  var urlIndex by remember { mutableIntStateOf(0) }
+  var reloadNonce by remember { mutableIntStateOf(0) }
+  // A monotonic clock rather than the Android sample's SystemClock, which does not exist here.
+  var requestStartedAt by remember { mutableStateOf(TimeSource.Monotonic.markNow()) }
+  var readout by remember { mutableStateOf(ImageReadout()) }
+
+  val url = if (source == LoadSource.Failure) {
+    FAILING_IMAGE_URL
+  } else {
+    playgroundImageUrls[urlIndex]
+  }
+
+  // Restarts the load. The image lives inside `key(reloadNonce)`, so bumping it drops the whole
+  // subtree and its remembered request, which is the only way to ask for the same url twice.
+  val startLoad: (Boolean) -> Unit = { clearMemory ->
+    if (clearMemory) {
+      landscapist.clearMemoryCache()
+    }
+    readout = ImageReadout()
+    requestStartedAt = TimeSource.Monotonic.markNow()
+    reloadNonce++
+  }
+
+  // Cache policies and progressive streaming are request-level, not plugin-level, so they go
+  // through the request builder rather than the component.
+  val requestBuilder = remember(source, toggles.progressive) {
+    playgroundRequestBuilder(
+      bypassCaches = source == LoadSource.Network,
+      progressive = toggles.progressive,
+    )
+  }
+
+  val zoomableState = rememberZoomableState(
+    config = ZoomableConfig(maxZoom = 8f, doubleTapZoom = 3f),
+    resetKey = url,
+  )
+  val thumbHashPlugin = remember { ThumbHashPlugin.fromBase64(SAMPLE_THUMB_HASH) }
+
+  // `rememberImageComponent` remembers without keys, so the component it hands back is the one
+  // built on the first composition and no switch flipped afterwards would ever reach the image.
+  // Keying the whole call on the toggles is what makes them take effect.
+  val component = key(toggles) {
+    rememberImageComponent {
+      if (toggles.crossfade) {
+        +CrossfadePlugin(duration = 450)
+      }
+      if (toggles.circularReveal) {
+        +CircularRevealPlugin(duration = 600)
+      }
+      if (toggles.shimmer) {
+        +ShimmerPlugin(
+          shimmer = Shimmer.Resonate(
+            baseColor = Color.DarkGray,
+            highlightColor = Color.LightGray,
+          ),
+        )
+      }
+      if (toggles.zoomable) {
+        +ZoomablePlugin(state = zoomableState)
+      }
+      if (toggles.blurHash) {
+        +BlurHashPlugin(blurHash = SAMPLE_BLUR_HASH, width = 32, height = 32)
+      }
+      if (toggles.thumbHash && thumbHashPlugin != null) {
+        +thumbHashPlugin
+      }
+      if (toggles.thumbnail) {
+        +ThumbnailPlugin(requestSize = IntSize(20, 20))
+      }
+      if (toggles.placeholder) {
+        // Flat colours rather than the Android sample's material icons: material-icons-core is
+        // not published for Compose Multiplatform 1.12, so there is no icon set to draw from.
+        +PlaceholderPlugin.Loading(ColorPainter(Color(0xFF3A3A3A)))
+        +PlaceholderPlugin.Failure(ColorPainter(Color(0xFF7A1F1F)))
+      }
+      if (toggles.progressive) {
+        +ProgressiveLoadingPlugin()
+      }
+    }
+  }
+
+  val imageOptions = remember(scaleMode) {
+    ImageOptions(contentScale = scaleMode.contentScale)
+  }
+
+  val cacheActions: List<Pair<String, () -> Unit>> = listOf(
+    "Reload" to { startLoad(false) },
+    "Clear memory" to { startLoad(true) },
+    "Clear all" to {
+      scope.launch {
+        landscapist.clearCaches()
+        startLoad(false)
+      }
+    },
+  )
+
+  val sizeModifier = when (sizeMode) {
+    SizeMode.Fixed -> Modifier.size(200.dp)
+    SizeMode.FillWidth -> Modifier.fillMaxWidth()
+    SizeMode.AspectRatio ->
+      Modifier
+        .fillMaxWidth()
+        .aspectRatio(16f / 9f)
+    SizeMode.Unsized -> Modifier
+  }
+
+  Column(
+    modifier = Modifier
+      .fillMaxWidth()
+      .verticalScroll(rememberScrollState()),
+  ) {
+    SectionHeader("Subject")
+
+    Box(
+      modifier = Modifier
+        .fillMaxWidth()
+        .padding(horizontal = 12.dp),
+    ) {
+      key(reloadNonce) {
+        LandscapistImage(
+          imageModel = { url },
+          modifier = sizeModifier.border(width = 1.dp, color = Color(0xFF9E9E9E)),
+          landscapist = landscapist,
+          requestBuilder = requestBuilder,
+          component = component,
+          imageOptions = imageOptions,
+          onImageStateChanged = { state ->
+            readout = state.toReadout(requestStartedAt.elapsedNow().inWholeMilliseconds)
+          },
+        )
+      }
+    }
+
+    ReadoutPanel(readout = readout, url = url)
+
+    SectionHeader("Loading source")
+    ChoiceRow(
+      options = LoadSource.entries,
+      selected = source,
+      label = { it.label },
+      onSelected = {
+        source = it
+        startLoad(false)
+      },
+    )
+    HintText(source.hint)
+    ActionRow(actions = cacheActions)
+    HintText(
+      "There is no disk cache in a browser, so the memory cache is the only one here and " +
+        "everything it loses goes back to the network.",
+    )
+
+    SectionHeader("Image")
+    ChoiceRow(
+      options = playgroundImageUrls.indices.toList(),
+      selected = urlIndex,
+      label = { "Image ${it + 1}" },
+      onSelected = {
+        urlIndex = it
+        startLoad(false)
+      },
+    )
+    HintText("Switching to an image that was never loaded is the only way to see a cold start.")
+
+    SectionHeader("Sizing")
+    ChoiceRow(
+      options = SizeMode.entries,
+      selected = sizeMode,
+      label = { it.label },
+      onSelected = { sizeMode = it },
+    )
+    HintText(
+      "The page scrolls vertically, so \"Fill width\" and \"No size\" are measured with an " +
+        "unbounded height.",
+    )
+    HintText(
+      "The wasm decoder hands the whole encoded image to Skia rather than sampling it down, so " +
+        "the decoded size in the readout stays the source size whatever is picked here. The " +
+        "layout still changes; only the decode does not.",
+    )
+
+    SectionHeader("Content scale")
+    ChoiceRow(
+      options = ScaleMode.entries,
+      selected = scaleMode,
+      label = { it.label },
+      onSelected = { scaleMode = it },
+    )
+
+    SectionHeader("Plugins")
+    HintText(
+      "Loading placeholders only show while a load is actually running. Pick the Network " +
+        "source, which disables the cache, to make one happen every time.",
+    )
+    PluginToggleList(
+      toggles = toggles,
+      onTogglesChanged = { toggles = it },
+    )
+
+    PlaygroundComparison(url = url, contentScale = scaleMode.contentScale)
+
+    Spacer(modifier = Modifier.height(32.dp))
+  }
+}
+
+/** Every plugin switch the wasm target supports. */
+@Composable
+private fun PluginToggleList(
+  toggles: PluginToggles,
+  onTogglesChanged: (PluginToggles) -> Unit,
+) {
+  ToggleRow("Crossfade (450ms)", toggles.crossfade) {
+    onTogglesChanged(toggles.copy(crossfade = it))
+  }
+  ToggleRow("CircularReveal (600ms)", toggles.circularReveal) {
+    onTogglesChanged(toggles.copy(circularReveal = it))
+  }
+  ToggleRow("Shimmer (while loading)", toggles.shimmer) {
+    onTogglesChanged(toggles.copy(shimmer = it))
+  }
+  ToggleRow("Zoomable (pinch, double click)", toggles.zoomable) {
+    onTogglesChanged(toggles.copy(zoomable = it))
+  }
+  if (toggles.zoomable) {
+    HintText(
+      "The zoom detector consumes the pointer down, so dragging over the image no longer " +
+        "scrolls the page. Tiling is off in a browser, which cannot decode a region, so this " +
+        "is pan and zoom over the one decoded bitmap.",
+    )
+  }
+  ToggleRow("BlurHash placeholder", toggles.blurHash) {
+    onTogglesChanged(toggles.copy(blurHash = it))
+  }
+  ToggleRow("ThumbHash placeholder", toggles.thumbHash) {
+    onTogglesChanged(toggles.copy(thumbHash = it))
+  }
+  ToggleRow("Thumbnail (20x20 preview)", toggles.thumbnail) {
+    onTogglesChanged(toggles.copy(thumbnail = it))
+  }
+  ToggleRow("Placeholder (loading + failure)", toggles.placeholder) {
+    onTogglesChanged(toggles.copy(placeholder = it))
+  }
+  ToggleRow("ProgressiveLoading", toggles.progressive) {
+    onTogglesChanged(toggles.copy(progressive = it))
+  }
+  HintText(
+    "ProgressiveLoading also turns on the request's progressive streaming, so the readout " +
+      "updates once per decode pass.",
+  )
+}
+
+/** Turns a loader state into the numbers the readout panel shows. */
+private fun LandscapistImageState.toReadout(elapsedMs: Long): ImageReadout = when (this) {
+  is LandscapistImageState.None -> ImageReadout(state = "None")
+  is LandscapistImageState.Loading -> ImageReadout(state = "Loading")
+  is LandscapistImageState.Success -> ImageReadout(
+    state = "Success",
+    width = originalWidth,
+    height = originalHeight,
+    dataSource = dataSource.name,
+    elapsedMs = elapsedMs,
+  )
+  is LandscapistImageState.Failure -> ImageReadout(
+    state = "Failure",
+    elapsedMs = elapsedMs,
+    failure = reason?.message ?: reason?.let { it::class.simpleName } ?: "unknown",
+  )
+}
+
+/**
+ * The request customisations that are not plugins. Built outside composition and remembered, so
+ * the request is stable and the load does not restart every frame.
+ */
+private fun playgroundRequestBuilder(
+  bypassCaches: Boolean,
+  progressive: Boolean,
+): (ImageRequest.Builder.() -> Unit)? {
+  if (!bypassCaches && !progressive) return null
+  return {
+    if (bypassCaches) {
+      memoryCachePolicy(CachePolicy.DISABLED)
+      diskCachePolicy(CachePolicy.DISABLED)
+    }
+    if (progressive) {
+      progressiveEnabled(true)
+    }
+  }
+}

--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/theme/Theme.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/theme/Theme.kt
@@ -1,0 +1,94 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Shapes
+import androidx.compose.material.Typography
+import androidx.compose.material.darkColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+internal val purple200: Color = Color(0xFF651FFF)
+internal val purple500: Color = Color(0xFF6200EA)
+internal val background: Color = Color(0xFF2B292B)
+internal val background800: Color = Color(0xFF424242)
+internal val white87: Color = Color(0xDDFFFFFF)
+
+private val DarkColorPalette = darkColors(
+  background = background,
+  onBackground = background800,
+  primary = purple200,
+  primaryVariant = purple500,
+  secondary = purple500,
+  onPrimary = Color.White,
+  onSecondary = Color.White,
+)
+
+private val DarkTypography = Typography(
+  h1 = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Bold,
+    color = Color.White,
+    fontSize = 28.sp,
+  ),
+  h2 = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Bold,
+    color = Color.White,
+    fontSize = 21.sp,
+  ),
+  body1 = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Normal,
+    color = Color.White,
+    fontSize = 14.sp,
+  ),
+  body2 = TextStyle(
+    fontFamily = FontFamily.Default,
+    fontWeight = FontWeight.Normal,
+    color = white87,
+    fontSize = 14.sp,
+  ),
+)
+
+private val shapes = Shapes(
+  small = RoundedCornerShape(4.dp),
+  medium = RoundedCornerShape(4.dp),
+  large = RoundedCornerShape(0.dp),
+)
+
+/**
+ * Dark only, unlike the Android sample's theme.
+ *
+ * The demo is embedded under the documentation site, which is itself dark, and a playground that
+ * changed palette with the visitor's system setting would not match the page around it.
+ */
+@Composable
+internal fun LandscapistDemoTheme(content: @Composable () -> Unit) {
+  MaterialTheme(
+    colors = DarkColorPalette,
+    typography = DarkTypography,
+    shapes = shapes,
+    content = content,
+  )
+}

--- a/demo-web/src/wasmJsMain/kotlin/com/github/skydoves/landscapistdemo/web/Main.kt
+++ b/demo-web/src/wasmJsMain/kotlin/com/github/skydoves/landscapistdemo/web/Main.kt
@@ -1,0 +1,24 @@
+/*
+ * Designed and developed by 2020-2023 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.skydoves.landscapistdemo.web
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+  ComposeViewport { DemoApp() }
+}

--- a/demo-web/src/wasmJsMain/resources/index.html
+++ b/demo-web/src/wasmJsMain/resources/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Landscapist playground</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            background: #2B292B;
+            color: #FFFFFF;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            overflow: hidden;
+        }
+
+        #loading {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            text-align: center;
+            padding: 0 24px;
+        }
+
+        #loading small {
+            color: #9E9E9E;
+            max-width: 32rem;
+            line-height: 1.5;
+        }
+    </style>
+</head>
+<body>
+<!--
+  ComposeViewport clears the body before it attaches its canvas, so this disappears on its own once
+  the demo is running, and stays put on a browser that cannot run it.
+-->
+<div id="loading">
+    <div>Loading the playground</div>
+    <small>
+        Compose for Web needs a browser with WebAssembly garbage collection: Chrome 119, Firefox
+        120, Safari 18.2 or newer. The first load fetches a few megabytes of Skia.
+    </small>
+</div>
+<script src="demo.js"></script>
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,13 @@ This library supports tracing image loading states, enabling you to compose cust
 
 Additionally, Landscapist offers the flexibility to configure and attach image-loading behaviors effortlessly using image plugins, allowing for swift and efficient customization. 
 
+## Try it in a browser
+
+The [playground](https://skydoves.github.io/landscapist/demo/) runs `landscapist-image` compiled to
+WebAssembly. Every image size, content scale and plugin combination is a switch, and the readout
+next to the image is what the loader reported. It needs a browser with WebAssembly garbage
+collection: Chrome 119, Firefox 120, Safari 18.2 or newer.
+
 ## Why Landscapist?
 
 Landscapist is a thoughtfully designed solution, meticulously crafted to optimize image loading performance in Jetpack Compose. The majority of its composable functions are marked as **Restartable** and **Skippable**, signifying significant improvements in recomposition performance, as measured by the Compose compiler metrics. Additionally, the library's performance has been enhanced further through the implementation of [Baseline Profiles](https://android-developers.googleblog.com/2022/01/improving-app-performance-with-baseline.html).

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -7,7 +7,7 @@ ws@8.18.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-ws@8.18.3:
-  version "8.18.3"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.20.1:
+  version "8.20.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.20.1.tgz#91a9ae2b312ccf98e0a85ec499b48cef45ab0ddb"
+  integrity sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ docs_dir: docs
 # Navigation
 nav:
   - 'Overview': index.md
+  # An absolute url rather than a path into docs/demo, which only exists after CI has built
+  # the wasm bundle into it. A path would break `mkdocs build` everywhere else.
+  - 'Web Demo': https://skydoves.github.io/landscapist/demo/
   - 'Landscapist (KMP)':
     - 'Landscapist Core': landscapist/landscapist-core.md
     - 'Landscapist Image': landscapist/landscapist-image.md  

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
 
 rootProject.name = "LandscapistDemo"
 include(":app")
+include(":demo-web")
 include(":bom")
 include(":landscapist")
 include(":landscapist-animation")


### PR DESCRIPTION
Adds `:demo-web`, the Android sample's playground compiled to WebAssembly, published to
https://skydoves.github.io/landscapist/demo/ on every push to main.

Every image size, content scale and plugin combination is a switch, and the panel under the image
is what the loader reported: state, decoded size, data source, elapsed time, failure.

### What is missing against the Android playground

None of these are fixable in this PR:

* **Palette.** `landscapist-palette` applies `landscapist.library.compose.multiplatform`, whose
  hierarchy template omits `withWasmJs()`, so `wasmJsMain` never gains a `dependsOn(commonMain)`
  edge and the published wasm klib is empty (597 bytes, no `default/ir/`). The root cause is
  upstream: `com.kmpalette:kmpalette-core:3.1.0` publishes no wasmJs variant.
* **BlurTransformation.** `landscapist-transformation` is an Android library with a JNI
  RenderScript blur and no KMP targets.
* **The Disk loading source**, since `createDefaultDiskCache` returns null on wasm.
* **The material icons** behind the placeholder plugin. `material-icons-core` is not published for
  Compose Multiplatform 1.12 and `material` does not depend on it, so the placeholders are flat
  colours.

Everything else is there: crossfade, circular reveal, shimmer, thumbnail, BlurHash, ThumbHash,
progressive, zoomable, four sizing modes, five content scales, and the side by side against Coil's
`AsyncImage`.

### Limits that are stated rather than hidden

Three things behave differently in a browser, and each gets a line of hint text next to the control
it affects:

* No disk cache, so the memory cache is the only one and everything it loses goes back to the
  network.
* No downsampling. `WasmImageDecoder` hands the whole encoded image to Skia, so the decoded size in
  the readout stays the source size whatever the sizing control is set to. The layout still changes;
  only the decode does not.
* No region decoding, so the zoomable plugin pans and zooms over the one decoded bitmap rather than
  tiling.

### How it is published

Into the mkdocs output, not to `gh-pages` on its own. `mkdocs gh-deploy --force` replaces that
branch with a commit whose tree is exactly `site/`, so a second publisher's `/demo/` would be gone
on the next push to main. `publish-docs.yml` builds the bundle, copies it into `docs/demo/`, and
lets mkdocs carry it. `docs/demo/` is generated, so it is gitignored next to `docs/api`.

The nav entry is an absolute url rather than a path into `docs/demo/`, which only exists after CI
has built it. A path would break `mkdocs build` everywhere else. Verified both ways.

### Two build details worth reading

* Both CI invocations pass `--no-configure-on-demand`. `gradle.properties` turns
  configure-on-demand on, and the wasm yarn lockfile is resolved from every configured project's
  `package.json`, so a build naming only `:demo-web:wasmJsBrowserDistribution` resolves a narrower
  lock than the committed one and `kotlinWasmStoreYarnLock` fails on the difference.
* `kotlin-js-store/wasm/yarn.lock` is updated. It had `ws@8.18.3` where the current dependency set
  wants `ws@8.20.1`, which nothing had noticed because no wasm binary in the repo was an
  executable before this one.

`android.yml` builds the demo on pull requests. Without it a broken demo would first appear as a
broken page on the site.

### Verification

`spotlessCheck`, `apiCheck` and `assemble` pass, and the demo bundle builds: 12 MB in total, of
which 8.2 MB is skiko and 3.0 MB is the app.

The production bundle was then driven in headless Chrome, both standalone and served from the built
mkdocs site at `/demo/`, with no page errors:

* first load reports `Success 1200x801 NETWORK 757 ms`
* reload reports `MEMORY 23 ms`
* the Network source with a reload goes back to `NETWORK`
* the Failure source reports `Failure` with `HTTP 404`
* all nine plugin switches turned on together, then a fresh network load with the whole stack
  attached, renders and reports `Success`

`mkdocs build` was checked with `docs/demo/` both present and absent, and the `.wasm` files are
served as `application/wasm`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive browser-based WebAssembly playground for comparing image loading, sizing, scaling, caching, and plugin behaviors.
  * Added controls and readouts for load status, image dimensions, source, timing, and failures.
  * Added a Web Demo link to the documentation and README.

* **Documentation**
  * Documented supported browser versions and playground capabilities.

* **Bug Fixes**
  * Pull request checks now verify that the web demo builds successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->