### PR TITLE
Make the unbounded axis tests wait for the image

### DIFF
--- a/landscapist-image/src/desktopTest/kotlin/com/skydoves/landscapist/image/UnboundedAxisTest.kt
+++ b/landscapist-image/src/desktopTest/kotlin/com/skydoves/landscapist/image/UnboundedAxisTest.kt
@@ -47,6 +47,7 @@ import com.skydoves.landscapist.core.network.ImageFetcher
 import com.skydoves.landscapist.crossfade.CrossfadePlugin
 import com.skydoves.landscapist.placeholder.shimmer.Shimmer
 import com.skydoves.landscapist.placeholder.shimmer.ShimmerPlugin
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
@@ -66,14 +67,28 @@ class UnboundedAxisTest {
 
   private val url = "https://example.com/photo.png"
 
+  /** How long a fetch takes, so the helpers below are measuring a load that actually happened. */
+  private val FetchDelayMillis = 30L
+
+  /** Generous, because it only has to be longer than a fetch on a loaded CI machine. */
+  private val WaitTimeoutMillis = 10_000L
+
   private fun loaderFor(width: Int, height: Int): Landscapist {
     val loader = Landscapist.builder()
       .noDiskCache()
       .fetcher(
         object : ImageFetcher {
           override fun canHandle(model: Any?): Boolean = true
-          override suspend fun fetch(request: ImageRequest): FetchResult =
-            FetchResult.Success(data = byteArrayOf(1), mimeType = "image/png")
+          override suspend fun fetch(request: ImageRequest): FetchResult {
+            // A fetch that returns on the same continuation is not a fetch any caller will ever
+            // see, and it hides the case these tests are about: the peek only answers from the
+            // memory cache when decoding again could not come back smaller, so an image larger
+            // than the row it is going into is fetched asynchronously and the first layout
+            // happens without it. Without this delay the helpers below can read a size that only
+            // a warm cache would have produced, and they pass whether or not they wait.
+            delay(FetchDelayMillis)
+            return FetchResult.Success(data = byteArrayOf(1), mimeType = "image/png")
+          }
         },
       )
       .decoder(
@@ -105,6 +120,7 @@ class UnboundedAxisTest {
   ): IntSize {
     val loader = loaderFor(imageWidth, imageHeight)
     var size: IntSize? = null
+    var loaded = false
     runComposeUiTest {
       setContent {
         Column(Modifier.size(200.dp).verticalScroll(rememberScrollState())) {
@@ -114,9 +130,12 @@ class UnboundedAxisTest {
             modifier = Modifier.fillMaxWidth().onGloballyPositioned { size = it.size },
             imageOptions = ImageOptions(contentScale = scale),
             requestBuilder = { diskCachePolicy(CachePolicy.DISABLED) },
+            onImageStateChanged = { if (it is LandscapistImageState.Success) loaded = true },
           )
         }
       }
+      waitUntil(timeoutMillis = WaitTimeoutMillis) { loaded }
+      waitForIdle()
     }
     return assertNotNull(size, "the composable never laid out")
   }
@@ -162,6 +181,7 @@ class UnboundedAxisTest {
   ): IntSize {
     val loader = loaderFor(imageWidth, imageHeight)
     var size: IntSize? = null
+    var loaded = false
     runComposeUiTest {
       setContent {
         Column(Modifier.size(200.dp).verticalScroll(rememberScrollState())) {
@@ -172,9 +192,12 @@ class UnboundedAxisTest {
             imageOptions = ImageOptions(contentScale = scale),
             component = rememberImageComponent { +CrossfadePlugin(duration = 50) },
             requestBuilder = { diskCachePolicy(CachePolicy.DISABLED) },
+            onImageStateChanged = { if (it is LandscapistImageState.Success) loaded = true },
           )
         }
       }
+      waitUntil(timeoutMillis = WaitTimeoutMillis) { loaded }
+      waitForIdle()
     }
     return assertNotNull(size, "the composable never laid out")
   }
@@ -210,6 +233,7 @@ class UnboundedAxisTest {
   ): IntSize {
     val loader = loaderFor(imageWidth, imageHeight)
     var size: IntSize? = null
+    var loaded = false
     runComposeUiTest {
       setContent {
         Row(Modifier.size(200.dp).horizontalScroll(rememberScrollState())) {
@@ -224,9 +248,12 @@ class UnboundedAxisTest {
               rememberImageComponent {}
             },
             requestBuilder = { diskCachePolicy(CachePolicy.DISABLED) },
+            onImageStateChanged = { if (it is LandscapistImageState.Success) loaded = true },
           )
         }
       }
+      waitUntil(timeoutMillis = WaitTimeoutMillis) { loaded }
+      waitForIdle()
     }
     return assertNotNull(size, "the composable never laid out")
   }
@@ -293,6 +320,7 @@ class UnboundedAxisTest {
   ): IntSize {
     val loader = loaderFor(80, 40)
     var size: IntSize? = null
+    var loaded = false
     runComposeUiTest {
       setContent {
         scrolls {
@@ -305,9 +333,12 @@ class UnboundedAxisTest {
               +CrossfadePlugin(duration = 50)
             },
             requestBuilder = { diskCachePolicy(CachePolicy.DISABLED) },
+            onImageStateChanged = { if (it is LandscapistImageState.Success) loaded = true },
           )
         }
       }
+      waitUntil(timeoutMillis = WaitTimeoutMillis) { loaded }
+      waitForIdle()
     }
     return assertNotNull(size, "the composable never laid out")
   }


### PR DESCRIPTION
`Android CI` failed on main after #995 with one test down:

```
UnboundedAxisTest[desktop] > Inside still shrinks an image too large for the row[desktop] FAILED
    java.lang.AssertionError at UnboundedAxisTest.kt:141
```

The same commit passed on its own pull request run, so this is a race, not a regression, and
nothing in #995 touched this code.

### What the race is

Every helper in `UnboundedAxisTest` reads whatever `onGloballyPositioned` last reported once
`setContent` returns, without waiting for the load:

```kotlin
runComposeUiTest {
  setContent { ... onGloballyPositioned { size = it.size } ... }
}
return assertNotNull(size, "the composable never laid out")
```

That is fine for most cases in the file. `loaderFor` warms the loader with a blocking load before
composing, so the node peeks the memory cache on its first measure and lays out with the image
already in hand.

It is not fine for this one. `peekMemoryCache` refuses a cached entry when decoding again could
come back smaller, and this is the only test whose image (800x400) is larger than the row it goes
into (200 wide). Its peek declines, the load goes asynchronous, and on a slow enough machine the
first and only layout happens with no image at all. The node then measures to no height, which is
exactly what CI reported.

### Confirming it rather than guessing

The test passes 15 times out of 15 on my machine, so I reproduced the CI condition instead of
waiting for it. Adding a delay to the test's fetcher fails it every time, with the same assertion
CI printed:

```
expected:<200 x 100> but was:<200 x 0>
```

### The fix

The fetcher now takes 30ms, and every helper waits for the load before its size is read.

The delay stays in. A fetch that returns on the same continuation is not a fetch any caller will
ever see, and it is what let this in: without it these tests pass whether or not they wait, so
nothing would have caught the missing wait. With the delay in place, deleting the wait from the one
helper reproduces the CI failure immediately, which is the check I ran to confirm the fix is the
thing doing the work.

### Verification

`spotlessCheck`, `desktopTest` and `testDebugUnitTest` pass: 744 tests, 0 failures. The
`UnboundedAxisTest` class is 13 tests, 0 failures, with the delay in place.

Test only. No library code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated image measurement tests to wait for asynchronous image loading to complete before validating dimensions.
  * Added a simulated loading delay to better reflect real-world image fetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->