### PR TITLE
Publish a Gradle version catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1503,6 +1503,34 @@ dependencies {
 }
  ```
 
+
+### Version catalog
+
+The BOM settles versions; it does not save you from writing each coordinate out.
+`landscapist-version-catalog` publishes every Landscapist artifact as a Gradle version catalog, so
+they arrive as aliases with completion in the IDE.
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("landscapistLibs") {
+            from("com.github.skydoves:landscapist-version-catalog:$version")
+        }
+    }
+}
+
+// build.gradle.kts
+dependencies {
+    implementation(landscapistLibs.landscapist.glide)
+    implementation(landscapistLibs.landscapist.placeholder)
+}
+```
+
+The two are not alternatives. The catalog carries coordinates for the lines you write; the BOM
+constrains versions across the whole resolution, including a module that arrives through another
+library. See the [documentation](https://skydoves.github.io/landscapist/bom/) for the full list.
+
  ## Taking Snapshot Images With Paparazzi
 
 [Paparazzi](https://github.com/cashapp/paparazzi) allows you to take snapshot images of your Composable functions without running them on physical devices. You can take proper snapshots images about your images with Paparazzi like the below:

--- a/buildSrc/src/main/kotlin/com/github/skydoves/landscapist/PublishedModules.kt
+++ b/buildSrc/src/main/kotlin/com/github/skydoves/landscapist/PublishedModules.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2020 skydoves
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.skydoves.landscapist
+
+/**
+ * Every module that goes to Maven Central, other than the BOM and the version catalog themselves.
+ *
+ * Two things publish this list: `bom/build.gradle.kts` constrains each of them to the release
+ * version, and `version-catalog/build.gradle.kts` turns each into a catalog alias. Adding a module
+ * in one place and forgetting the other is how `landscapist-image-gallery` ended up in the BOM but
+ * missing from the documented dependency list for several releases, so the list lives here and
+ * both read it.
+ *
+ * @property path The Gradle project path.
+ * @property artifactId The artifact id it publishes under, which is not always the project name.
+ * @property alias The version catalog alias, which reads as `landscapistLibs.<alias with dots>`.
+ */
+data class PublishedModule(
+  val path: String,
+  val artifactId: String,
+  val alias: String,
+)
+
+object PublishedModules {
+  val all: List<PublishedModule> = listOf(
+    PublishedModule(":landscapist", "landscapist", "landscapist"),
+    PublishedModule(":landscapist-core", "landscapist-core", "landscapist-core"),
+    PublishedModule(":landscapist-image", "landscapist-image", "landscapist-image"),
+    PublishedModule(":landscapist-svg", "landscapist-svg", "landscapist-svg"),
+    PublishedModule(
+      ":landscapist-image-gallery",
+      "landscapist-image-gallery",
+      "landscapist-image-gallery",
+    ),
+    PublishedModule(":landscapist-animation", "landscapist-animation", "landscapist-animation"),
+    PublishedModule(
+      ":landscapist-placeholder",
+      "landscapist-placeholder",
+      "landscapist-placeholder",
+    ),
+    PublishedModule(":landscapist-palette", "landscapist-palette", "landscapist-palette"),
+    PublishedModule(
+      ":landscapist-transformation",
+      "landscapist-transformation",
+      "landscapist-transformation",
+    ),
+    PublishedModule(":landscapist-zoomable", "landscapist-zoomable", "landscapist-zoomable"),
+    PublishedModule(":glide", "landscapist-glide", "landscapist-glide"),
+    PublishedModule(":coil", "landscapist-coil", "landscapist-coil"),
+    PublishedModule(":coil3", "landscapist-coil3", "landscapist-coil3"),
+    PublishedModule(":fresco", "landscapist-fresco", "landscapist-fresco"),
+    PublishedModule(
+      ":fresco-websupport",
+      "landscapist-fresco-websupport",
+      "landscapist-fresco-websupport",
+    ),
+  )
+}

--- a/docs/bom.md
+++ b/docs/bom.md
@@ -55,3 +55,42 @@ The Landscapist Bill of Materials (BOM) simplifies the management of all Landsca
     ```
 
 This ensures a streamlined and efficient development process, as you can easily keep track of library versions and ensure compatibility across your Landscapist dependencies. 
+## Version catalog
+
+The BOM settles versions. It does not save you from writing each coordinate out, and it gives you
+nothing to discover the modules from. `landscapist-version-catalog` is the other half: a published
+[Gradle version catalog](https://docs.gradle.org/current/userguide/version_catalogs.html) of every
+Landscapist artifact, so they arrive as aliases with completion in the IDE.
+
+Import it once in `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("landscapistLibs") {
+            from("com.github.skydoves:landscapist-version-catalog:$version")
+        }
+    }
+}
+```
+
+Then declare dependencies by alias, with no version and no coordinate string:
+
+```kotlin
+dependencies {
+    implementation(landscapistLibs.landscapist.glide)
+    implementation(landscapistLibs.landscapist.coil3)
+    implementation(landscapistLibs.landscapist.image)
+    implementation(landscapistLibs.landscapist.placeholder)
+}
+```
+
+Every module on this page has an alias, and so does the BOM itself, as
+`landscapistLibs.landscapist.bom`.
+
+!!! note "Which one do I want?"
+
+    They are not alternatives. The catalog carries the coordinates and a version for the lines you
+    write yourself. The BOM constrains versions across the whole resolution, including a Landscapist
+    module that arrives through some other library rather than through your build file. Taking both
+    is reasonable: the aliases for what you declare, the BOM for what you do not.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,7 +41,7 @@ nav:
   - 'Zoomable': zoomable.md
   - 'Image Gallery': gallery.md
   - 'Image Component and Plugin': image-component-and-plugin.md
-  - 'BOM': bom.md
+  - 'BOM and Version Catalog': bom.md
   - 'Snapshots With Paparazzi': snapshots-with-paparazzi.md
   - 'Version Map': version-map.md
   - 'Sponsor 🩷': sponsor.md

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ rootProject.name = "LandscapistDemo"
 include(":app")
 include(":demo-web")
 include(":bom")
+include(":version-catalog")
 include(":landscapist")
 include(":landscapist-animation")
 include(":landscapist-palette")

--- a/version-catalog/build.gradle.kts
+++ b/version-catalog/build.gradle.kts
@@ -16,31 +16,46 @@
 
 import com.github.skydoves.landscapist.Configuration
 import com.github.skydoves.landscapist.PublishedModules
+import com.vanniktech.maven.publish.VersionCatalog
 
 plugins {
-  kotlin("jvm")
+  `version-catalog`
   id(libs.plugins.nexus.plugin.get().pluginId)
 }
 
 apply(from = "${rootDir}/scripts/publish-module.gradle.kts")
 
+val libVersion = rootProject.extra.get("libVersion").toString()
+
+// Coordinates rather than version alignment, which is what the BOM is for. A consumer who wants
+// both takes the alias from here and keeps the BOM for the alignment it does on modules that
+// arrive transitively.
+catalog {
+  versionCatalog {
+    val landscapist = version("landscapist", libVersion)
+
+    PublishedModules.all.forEach { module ->
+      library(module.alias, Configuration.artifactGroup, module.artifactId)
+        .versionRef(landscapist)
+    }
+
+    // The BOM is in here too, so a consumer can take the alignment without hand writing the one
+    // coordinate the catalog was meant to save them from writing.
+    library("landscapist-bom", Configuration.artifactGroup, "landscapist-bom")
+      .versionRef(landscapist)
+  }
+}
+
 mavenPublishing {
-  val artifactId = "landscapist-bom"
+  val artifactId = "landscapist-version-catalog"
+  configure(VersionCatalog())
   coordinates(
     Configuration.artifactGroup,
     artifactId,
-    rootProject.extra.get("libVersion").toString()
+    libVersion
   )
 
   pom {
     name.set(artifactId)
-  }
-}
-
-dependencies {
-  constraints {
-    // The same list the version catalog publishes, so a module cannot reach one and miss the
-    // other. See PublishedModules in buildSrc.
-    PublishedModules.all.forEach { api(project(it.path)) }
   }
 }


### PR DESCRIPTION
Closes #993.

Publishes `landscapist-version-catalog`, a Gradle version catalog of every Landscapist artifact.

```kotlin
// settings.gradle.kts
dependencyResolutionManagement {
    versionCatalogs {
        create("landscapistLibs") {
            from("com.github.skydoves:landscapist-version-catalog:2.13.0")
        }
    }
}

// build.gradle.kts
dependencies {
    implementation(landscapistLibs.landscapist.glide)
    implementation(landscapistLibs.landscapist.placeholder)
}
```

### Why this is not the BOM again

They solve adjacent problems, so the docs say which is which rather than leaving a reader to guess:

* The catalog carries **coordinates**. It is what saves you from typing
  `com.github.skydoves:landscapist-image-gallery` and finding out at resolution time that you got a
  character wrong. It also means `landscapistLibs.` lists the modules, which today only
  `docs/bom.md` does.
* The BOM carries **version alignment**, across the whole resolution. If another library drags in
  `landscapist-placeholder` at an older version, the BOM lifts it; the catalog has no say, because
  it only touches the lines you wrote yourself.

Taking both is reasonable, and the catalog carries an alias for the BOM so that is one line too.

### The list is single sourced

The published module list moves to `PublishedModules` in `buildSrc`, and `bom/build.gradle.kts` and
`version-catalog/build.gradle.kts` both read it:

```kotlin
dependencies {
  constraints {
    PublishedModules.all.forEach { api(project(it.path)) }
  }
}
```

Without this the catalog would be a third hand maintained copy of the same fifteen coordinates, and
that has already gone wrong here once: `landscapist-image-gallery` was in the BOM but missing from
the documented dependency list for several releases, and was only added during the 2.13.0 release
prep.

### What the module actually publishes

`generateCatalogAsToml` output, all fifteen modules plus the BOM, at the release version:

```toml
[versions]
landscapist = "2.13.0"

[libraries]
landscapist = {group = "com.github.skydoves", name = "landscapist", version.ref = "landscapist" }
landscapist-animation = {group = "com.github.skydoves", name = "landscapist-animation", version.ref = "landscapist" }
landscapist-bom = {group = "com.github.skydoves", name = "landscapist-bom", version.ref = "landscapist" }
landscapist-coil = ...
landscapist-coil3 = ...
landscapist-core = ...
landscapist-fresco = ...
landscapist-fresco-websupport = ...
landscapist-glide = ...
landscapist-image = ...
landscapist-image-gallery = ...
landscapist-palette = ...
landscapist-placeholder = ...
landscapist-svg = ...
landscapist-transformation = ...
landscapist-zoomable = ...
```

The pom is `<packaging>toml</packaging>` under `com.github.skydoves:landscapist-version-catalog`,
and picks up the shared licence, url and description from `scripts/publish-module.gradle.kts` like
every other module. The version comes from `libVersion`, so it tracks releases without another edit
during release prep.

### Notes on the issue as filed

Two small corrections, neither of which changes the conclusion:

* The issue says the coordinates are already centralized in `gradle/libs.versions.toml`. That file
  is this build's own dependency catalog (Kotlin, AGP, Coil, Ktor). Landscapist's published
  coordinates were spread across each module's `mavenPublishing { coordinates(...) }` and
  `bom/build.gradle.kts`. Hence `PublishedModules`.
* The example lists `landscapist-coil`, which is the Android only Coil v2 binding. The Kotlin
  Multiplatform one is `landscapist-coil3`. Both are in the catalog.

### Verification

`spotlessCheck`, `apiCheck`, `assemble`, `desktopTest`, `testDebugUnitTest` and the web demo
distribution pass on JDK 21. 744 tests, 0 failures. `mkdocs build` succeeds.

The BOM's generated pom is unchanged by the refactor: the same fifteen artifacts, all constrained
at 2.13.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `landscapist-version-catalog` Gradle version catalog, providing dependency aliases and IDE completion for Landscapist libraries.
  * Added catalog support for the Landscapist BOM to help keep dependency versions consistent.

* **Documentation**
  * Added setup instructions and usage examples for the version catalog.
  * Clarified how the version catalog and BOM work together.
  * Updated navigation to include the combined BOM and Version Catalog documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->