### PR TITLE
Stop the web demo footer collapsing at narrow widths

### DIFF
--- a/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/DemoApp.kt
+++ b/demo-web/src/commonMain/kotlin/com/github/skydoves/landscapistdemo/web/DemoApp.kt
@@ -141,28 +141,59 @@ private fun Masthead() {
   )
 }
 
+/**
+ * Narrower than this and the footer stacks its blurb above the links.
+ *
+ * Below it the blurb alone wants most of the row, and a `Row` hands an unweighted child the width
+ * it asks for before the next child is measured, so the links were left a few pixels and rendered
+ * one character per line on top of each other.
+ */
+private const val FooterStackWidthDp = 620
+
 @Composable
 private fun Footer() {
-  val uriHandler = LocalUriHandler.current
   Divider()
   VSpace(14)
-  Row(
-    modifier = Modifier.fillMaxWidth(),
-    horizontalArrangement = Arrangement.SpaceBetween,
-    verticalAlignment = Alignment.CenterVertically,
-  ) {
-    Text(
-      text = "Built from the :demo-web module, a port of the Android sample's playground.",
-      style = DemoType.Hint,
-      color = DemoColors.TextFaint,
-    )
-    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-      LinkText("Documentation", onClick = { uriHandler.openUri(DOCUMENTATION_URL) })
-      LinkText(
-        label = "github.com/skydoves/landscapist",
-        color = DemoColors.Accent,
-        onClick = { uriHandler.openUri(REPOSITORY_URL) },
-      )
+  BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+    if (maxWidth < FooterStackWidthDp.dp) {
+      Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        FooterBlurb()
+        FooterLinks()
+      }
+    } else {
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        verticalAlignment = Alignment.Top,
+      ) {
+        // Weighted, so the blurb takes what is left rather than everything. Without it the links
+        // are measured against whatever the sentence did not want.
+        FooterBlurb(modifier = Modifier.weight(1f))
+        FooterLinks()
+      }
     }
+  }
+}
+
+@Composable
+private fun FooterBlurb(modifier: Modifier = Modifier) {
+  Text(
+    text = "Built from the :demo-web module, a port of the Android sample's playground.",
+    style = DemoType.Hint,
+    color = DemoColors.TextFaint,
+    modifier = modifier,
+  )
+}
+
+@Composable
+private fun FooterLinks() {
+  val uriHandler = LocalUriHandler.current
+  Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+    LinkText("Documentation", onClick = { uriHandler.openUri(DOCUMENTATION_URL) })
+    LinkText(
+      label = "github.com/skydoves/landscapist",
+      color = DemoColors.Accent,
+      onClick = { uriHandler.openUri(REPOSITORY_URL) },
+    )
   }
 }


### PR DESCRIPTION
Fixes #1000. The fix is the one @komodgn proposed in the issue, verified and applied.

### The bug is real, and worse than the report describes

`Row` hands an unweighted child the width it asks for before the next child is measured. The blurb
took what it wanted and the links were measured against the remainder.

At 380 wide that remainder is a few pixels. Both links rendered one character per line, drawn on
top of each other, in a column roughly four hundred pixels tall:

```
                                        t
                                        b m
                                        e
                                        n
 Built from the :demo-web module,       t
 a port of the Android sample's         o m
 playground.                            r
                                        y
                                        o k
                                        y
                                        d
```

At 700 it is not catastrophic but already wrong: `github.com/skydoves/landscapist` wraps onto two
lines and runs into `Documentation`.

### The fix

The footer switches on width, the same way the page already switches between one and two columns:

* below `FooterStackWidthDp` (620) the blurb stacks above the links
* above it they stay on one row, and the blurb is `weight(1f)` so it takes what is left rather than
  everything

`SpaceBetween` goes away because the weighted blurb already pushes the links to the right edge.

I kept @komodgn's structure, including the `FooterBlurb` / `FooterLinks` extraction, and added a
comment on the constant saying what goes wrong without it, since the failure mode is not obvious
from reading the `Row`.

### Verification

Built and driven in a browser at 380, 520, 640, 700, 760 and 1440 wide.

| viewport | footer width inside the page column | layout |
|---|---|---|
| 380 | 340 | stacked, both links on one line |
| 520 | 480 | stacked |
| 640 | 600 | stacked |
| 700 | 660 | one row, blurb wraps to two lines, links flush right |
| 1440 | 1080 | one row, unchanged from before |

Note the threshold is on the footer's own width, not the viewport: the page column is capped at
1120dp with 20dp padding, so the switch happens around a 660 wide viewport.

No page errors at any width. `spotlessCheck`, `apiCheck` and the demo distribution pass.

### On the report

@komodgn asked whether they could send a PR. They did the diagnosis and the design here and I only
verified and applied it, so if you would rather take theirs, close this one and I will not mind at
all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the footer’s responsive layout for narrow screens by stacking the description above the links.
  * Preserved the side-by-side footer layout on wider screens while maintaining link spacing.
  * Improved footer alignment and presentation across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->